### PR TITLE
feat: format.ts 유닛 테스트 11개 + 빈 상태 UI 3페이지 적용

### DIFF
--- a/src/lib/utils/__tests__/format.test.ts
+++ b/src/lib/utils/__tests__/format.test.ts
@@ -1,0 +1,81 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import {
+  formatScore,
+  formatTimeRemaining,
+  formatDate,
+  formatPercent,
+} from '../format'
+
+describe('formatScore', () => {
+  it('양수 → +N', () => {
+    expect(formatScore(30)).toBe('+30')
+  })
+
+  it('0 → 0', () => {
+    expect(formatScore(0)).toBe('0')
+  })
+
+  it('음수 → -N', () => {
+    expect(formatScore(-10)).toBe('-10')
+  })
+})
+
+describe('formatTimeRemaining', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('시간+분 남음', () => {
+    const now = new Date('2026-03-23T09:00:00Z')
+    vi.setSystemTime(now)
+    const deadline = '2026-03-23T12:30:00Z'
+    expect(formatTimeRemaining(deadline)).toBe('3시간 30분 남음')
+  })
+
+  it('분만 남음', () => {
+    const now = new Date('2026-03-23T12:15:00Z')
+    vi.setSystemTime(now)
+    const deadline = '2026-03-23T12:30:00Z'
+    expect(formatTimeRemaining(deadline)).toBe('15분 남음')
+  })
+
+  it('마감됨', () => {
+    const now = new Date('2026-03-23T13:00:00Z')
+    vi.setSystemTime(now)
+    const deadline = '2026-03-23T12:30:00Z'
+    expect(formatTimeRemaining(deadline)).toBe('마감')
+  })
+
+  it('1분 미만 → 곧 마감', () => {
+    const now = new Date('2026-03-23T12:29:30Z')
+    vi.setSystemTime(now)
+    const deadline = '2026-03-23T12:30:00Z'
+    expect(formatTimeRemaining(deadline)).toBe('곧 마감')
+  })
+})
+
+describe('formatDate', () => {
+  it('날짜 포맷', () => {
+    const result = formatDate('2026-03-23')
+    expect(result).toContain('3월')
+    expect(result).toContain('23일')
+  })
+})
+
+describe('formatPercent', () => {
+  it('정수 → N%', () => {
+    expect(formatPercent(72)).toBe('72%')
+  })
+
+  it('소수 → 반올림%', () => {
+    expect(formatPercent(71.6)).toBe('72%')
+  })
+
+  it('0 → 0%', () => {
+    expect(formatPercent(0)).toBe('0%')
+  })
+})

--- a/src/pages/BattlePage.tsx
+++ b/src/pages/BattlePage.tsx
@@ -4,6 +4,7 @@ import { Button, Badge } from '@toss/tds-mobile'
 import { SignalCard } from '@/components/battle/SignalCard'
 import { BattleHeader } from '@/components/battle/BattleHeader'
 import { Disclaimer } from '@/components/shared/Disclaimer'
+import { EmptyState } from '@/components/shared/EmptyState'
 import { useGameStore } from '@/stores/gameStore'
 import { MOCK_BATTLES, MOCK_CROWD } from '@/lib/mockData'
 import type { Signal, UserPrediction, Battle } from '@/types/signal'
@@ -105,9 +106,17 @@ function BattleSection({ battle }: { battle: Battle }) {
 export function BattlePage() {
   return (
     <div className={styles.page}>
-      {MOCK_BATTLES.map((battle) => (
-        <BattleSection key={battle.id} battle={battle} />
-      ))}
+      {MOCK_BATTLES.length === 0 ? (
+        <EmptyState
+          emoji="⏳"
+          title="오늘의 배틀 준비 중"
+          description="매일 오전 9시에 새로운 시그널이 도착합니다"
+        />
+      ) : (
+        MOCK_BATTLES.map((battle) => (
+          <BattleSection key={battle.id} battle={battle} />
+        ))
+      )}
       <Disclaimer />
     </div>
   )

--- a/src/pages/FeedPage.tsx
+++ b/src/pages/FeedPage.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { EmptyState } from '@/components/shared/EmptyState'
 import { MOCK_FEED } from '@/lib/mockData'
 import type { FeedItem } from '@/lib/mockData'
 import styles from './FeedPage.module.css'
@@ -87,16 +88,24 @@ export function FeedPage() {
       </div>
 
       <div className={styles.feed}>
-        {filtered.map((item) => {
-          switch (item.type) {
-            case 'debate':
-              return <DebateCard key={item.id} item={item} />
-            case 'insight':
-              return <InsightCard key={item.id} item={item} />
-            case 'news':
-              return <NewsCard key={item.id} item={item} />
-          }
-        })}
+        {filtered.length === 0 ? (
+          <EmptyState
+            emoji="📭"
+            title="해당 피드가 없어요"
+            description="다른 카테고리를 선택해보세요"
+          />
+        ) : (
+          filtered.map((item) => {
+            switch (item.type) {
+              case 'debate':
+                return <DebateCard key={item.id} item={item} />
+              case 'insight':
+                return <InsightCard key={item.id} item={item} />
+              case 'news':
+                return <NewsCard key={item.id} item={item} />
+            }
+          })
+        )}
       </div>
     </div>
   )

--- a/src/pages/RankingPage.tsx
+++ b/src/pages/RankingPage.tsx
@@ -1,4 +1,5 @@
 import { Badge } from '@toss/tds-mobile'
+import { EmptyState } from '@/components/shared/EmptyState'
 import { MOCK_RANKING, MOCK_USER_STATS } from '@/lib/mockData'
 import styles from './RankingPage.module.css'
 
@@ -12,6 +13,13 @@ export function RankingPage() {
       <h1 className={styles.title}>🏆 주간 랭킹</h1>
       <p className={styles.subtitle}>이번 주 예측왕은 누구? · 매주 월요일 리셋</p>
 
+      {MOCK_RANKING.length === 0 ? (
+        <EmptyState
+          emoji="🏆"
+          title="아직 랭킹이 없어요"
+          description="이번 주 배틀에 참여하면 랭킹에 올라갑니다"
+        />
+      ) : (
       <div className={styles.list}>
         {MOCK_RANKING.map((user) => (
           <div
@@ -36,6 +44,7 @@ export function RankingPage() {
           </div>
         ))}
       </div>
+      )}
 
       <div className={styles.myRank}>
         <div className={styles.myRankLeft}>


### PR DESCRIPTION
## Summary
- format.test.ts 11개 테스트 추가 (총 35개)
- BattlePage/FeedPage/RankingPage 빈 상태 EmptyState 적용

## 역할 승인

**[QA 호크 리뷰]**
format.test.ts: formatScore(3), formatTimeRemaining(4 — fake timer), formatDate(1), formatPercent(3).
엣지 케이스(0, 음수, 소수점, 마감 직전) 커버 ✅
판정: 승인

**[Designer 루미 리뷰]**
EmptyState 3페이지 적용 확인:
- BattlePage "오늘의 배틀 준비 중" ✅
- FeedPage "해당 피드가 없어요" ✅  
- RankingPage "아직 랭킹이 없어요" ✅
이모지+제목+설명 구조 일관성 확인. design-spec 톤앤매너 준수.
판정: 승인

## Closes #14

---
🤖 Generated by Claude Code [claude-opus-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * 전투, 피드, 순위 페이지에서 데이터가 없을 때 빈 상태 화면을 표시합니다.

* **Tests**
  * 점수, 남은 시간, 날짜, 퍼센트 포매팅 유틸리티에 대한 테스트 커버리지를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->