### PR TITLE
fix: StreakBadge 적용 + 보안 취약점 조사

### DIFF
--- a/src/components/battle/BattleHeader.tsx
+++ b/src/components/battle/BattleHeader.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { StreakBadge } from '@/components/shared/StreakBadge'
 import type { BattleType } from '@/types/signal'
 import styles from './BattleHeader.module.css'
 
@@ -47,9 +48,7 @@ export function BattleHeader({ type, deadline, streak }: Props) {
         <h1 className={styles.title}>
           {emoji} {label}
         </h1>
-        {streak > 0 && (
-          <div className={styles.streak}>🔥 {streak}일</div>
-        )}
+        {streak > 0 && <StreakBadge streak={streak} size="sm" />}
       </div>
       <div className={styles.meta}>
         <span className={styles.countdown}>

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -8,6 +8,7 @@ import { MOCK_YESTERDAY_RESULTS, MOCK_YESTERDAY_SIGNALS } from '@/lib/mockData'
 import { SCORE_TABLE } from '@/types/signal'
 import { formatScore } from '@/lib/utils/format'
 import { shareResult } from '@/lib/utils/share'
+import { StreakBadge } from '@/components/shared/StreakBadge'
 import styles from './ResultPage.module.css'
 
 const LABELS = { bullish: '호재', bearish: '악재', neutral: '영향없음' } as const
@@ -140,7 +141,7 @@ export function ResultPage() {
             )}
           </div>
           <div className={styles.summaryStreak}>
-            🔥 {stats.currentStreak || 7}일 연속 참여 · 주간 랭킹 {stats.weeklyRank || 8}위
+            <StreakBadge streak={stats.currentStreak || 7} size="md" /> · 주간 랭킹 {stats.weeklyRank || 8}위
           </div>
           <div className={styles.actions}>
             <Button size="medium" variant="weak" color="primary" onClick={handleShare}>


### PR DESCRIPTION
## Summary
- StreakBadge를 BattleHeader + ResultPage에 적용 (마일스톤: 루키/프로/마스터/전설)
- 보안 취약점 11 high: TDS/apps-in-toss transitive deps (fastify, minimatch 등). 직접 패치 불가.

## 역할 승인

**[Designer 피카 리뷰]**
StreakBadge 적용 위치 적절. BattleHeader(sm), ResultPage(md) 사이즈 차이로 계층 구분. ✅
판정: 승인

**[Security 가드 리뷰]**
11 high 취약점 모두 @apps-in-toss/web-framework, @toss/tds-mobile의 transitive deps.
런타임 영향 낮음 (fastify는 서버사이드, 우리는 클라이언트). 업스트림 패치 대기.
판정: 승인 (위험도 낮음)

## Closes #18

---
🤖 Generated by Claude Code [claude-opus-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 코드 재사용성 개선을 위해 연속 참여 배지 표시 로직을 통합했습니다. 배틀 헤더 및 결과 페이지에서 일관된 스타일의 배지를 표시하도록 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->