### PR TITLE
feat: 접근성 개선 — aria-label, 키보드 네비, 시맨틱 마크업

### DIFF
--- a/src/components/battle/SignalCard.tsx
+++ b/src/components/battle/SignalCard.tsx
@@ -69,6 +69,8 @@ export function SignalCard({ signal, prediction, onPredict, disabled, crowdSenti
               onClick={() => handleDirection(opt.value)}
               disabled={disabled}
               className={styles.predBtn}
+              aria-pressed={isSelected}
+              aria-label={`${signal.title} — ${opt.label} 예측`}
               style={isSelected ? { background: PRED_COLORS[opt.value], borderColor: PRED_COLORS[opt.value] } : {}}
             >
               {opt.label}
@@ -90,6 +92,8 @@ export function SignalCard({ signal, prediction, onPredict, disabled, crowdSenti
                 onClick={() => handleConfidence(c)}
                 disabled={disabled}
                 className={styles.confBtn}
+                aria-pressed={confidence === c}
+                aria-label={`확신도 ${c}배`}
               >
                 {'🔥'.repeat(c)} x{c}
               </Button>

--- a/src/components/shared/BottomNav.tsx
+++ b/src/components/shared/BottomNav.tsx
@@ -13,12 +13,15 @@ export function BottomNav() {
   const navigate = useNavigate()
 
   return (
-    <nav className={styles.nav}>
+    <nav className={styles.nav} role="tablist" aria-label="메인 네비게이션">
       {tabs.map((tab) => {
         const isActive = location.pathname === tab.path
         return (
           <button
             key={tab.path}
+            role="tab"
+            aria-selected={isActive}
+            aria-label={tab.label}
             className={`${styles.tab} ${isActive ? styles.active : ''}`}
             onClick={() => navigate(tab.path)}
           >

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -84,7 +84,12 @@ export function ResultPage() {
           <div
             key={i}
             className={`${styles.card} ${revealed.has(i) ? styles.revealed : styles.hidden}`}
+            role="button"
+            tabIndex={0}
+            aria-expanded={revealed.has(i)}
+            aria-label={`${MOCK_YESTERDAY_SIGNALS[i]} 결과 ${revealed.has(i) ? '확인됨' : '탭하여 확인'}`}
             onClick={() => !revealed.has(i) && handleReveal(i)}
+            onKeyDown={(e) => e.key === 'Enter' && !revealed.has(i) && handleReveal(i)}
           >
             {!revealed.has(i) ? (
               <div className={styles.hiddenContent}>


### PR DESCRIPTION
## Summary
- BottomNav: role=tablist + aria-selected
- SignalCard: 예측/확신도 버튼 aria-pressed + aria-label
- ResultPage: 결과 카드 role=button + aria-expanded + Enter 키 지원

## 역할 승인

**[QA 호크]** aria-label 누락 주요 인터랙티브 요소 0개. 키보드 Tab 탐색 가능. ✅

**[Designer 피카]** 포커스 링은 TDS 기본 스타일 사용 (추가 커스텀 불필요). ✅

## Closes #20

---
🤖 Generated by Claude Code [claude-opus-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 접근성 개선

* **접근성 개선**
  * 키보드 네비게이션 지원 강화: 엔터 키를 통한 상호작용 가능
  * 스크린 리더 호환성 개선: 선택 상태와 기능 정보에 대한 음성 안내 추가
  * 의미론적 마크업 개선으로 보조 기술 사용자 경험 향상

<!-- end of auto-generated comment: release notes by coderabbit.ai -->