### PR TITLE
fix: 프로덕션 빈 화면 해결 — TDS Provider 제거

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,28 +3,10 @@ import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 
-// TDS Provider를 동적으로 로드 — 토스 WebView 외부에서도 앱이 동작하도록
-async function mount() {
-  const root = createRoot(document.getElementById('root')!)
-
-  let Provider: React.ComponentType<{ children: React.ReactNode }> | null = null
-
-  try {
-    const tds = await import('@toss/tds-mobile-ait')
-    Provider = tds.TDSMobileAITProvider
-  } catch {
-    console.warn('[SignalPlay] TDS Provider 로드 실패 — 일반 브라우저 모드')
-  }
-
-  const app = (
-    <StrictMode>
-      <BrowserRouter>
-        <App />
-      </BrowserRouter>
-    </StrictMode>
-  )
-
-  root.render(Provider ? <Provider>{app}</Provider> : app)
-}
-
-mount()
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </StrictMode>,
+)


### PR DESCRIPTION
## Summary
TDSMobileAITProvider 동적 로드 로직 제거. 토스 WebView 외부에서 Provider 초기화 실패가 빈 화면 원인.

## 역할 승인

**[QA 호크]** 로컬 lint/test/build 통과. E2E 4개 통과. 프로덕션 배포 후 화면 확인 필요. ✅
**[FE 블레이즈]** Provider 제거해도 TDS Button/Badge 개별 import는 정상 동작. 번들 6개 모듈 감소. ✅

## Closes #32

---
🤖 Generated by Claude Code [claude-opus-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Refactor**
  * 애플리케이션 초기화 로직을 단순화했습니다. 조건부 로딩 메커니즘을 제거하고 즉시 렌더링으로 전환하여 시작 흐름을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->