### PR TITLE
feat: Gemini Google Search Grounding — 실시간 뉴스 기반 질문 생성

### DIFF
--- a/api/question.ts
+++ b/api/question.ts
@@ -9,9 +9,10 @@ const CHARACTER_META: Record<string, { name: string; emoji: string; methodology:
   chimp: { name: '다트침팬지', emoji: '🐵', methodology: '다트 던지기' },
 }
 
-const QUESTION_PROMPT = `당신은 투자 뉴스 편집자입니다. 오늘의 주요 경제/주식 이슈 중에서 투자자들의 의견이 갈릴 만한 질문 1개를 만들어주세요.
-좋은 질문: 구체적 종목/이벤트 기반, 호재/악재 의견 갈림, 오늘/이번 주 실제 이벤트.
-나쁜 질문: 추상적, 암호화폐 관련.
+const buildQuestionPrompt = (today: string) =>
+  `당신은 투자 뉴스 편집자입니다. 오늘(${today}) 실제 발생한 주요 경제/주식 뉴스를 검색하여, 투자자들의 의견이 갈릴 만한 질문 1개를 만들어주세요.
+좋은 질문: 오늘 실제 보도된 구체적 종목/이벤트 기반, 호재/악재 의견 갈림.
+나쁜 질문: 추상적, 암호화폐 관련, 오래된 이슈.
 JSON으로만 응답: {"title":"이슈 제목(15자)","question":"투표 질문(25자, ~일까?)","category":"종목|지수|매크로"}`
 
 const CHARACTER_PROMPT = `당신은 5명의 AI 투자 점쟁이입니다. 질문에 대해 각자 방법론으로 예측합니다.
@@ -25,17 +26,19 @@ const GEMINI_URL = 'https://generativelanguage.googleapis.com/v1beta/models/gemi
 
 let cache: { date: string; data: unknown } | null = null
 
-async function callGemini(prompt: string): Promise<string | null> {
+async function callGemini(prompt: string, useSearch = false): Promise<string | null> {
   if (!GEMINI_API_KEY) return null
   try {
+    const body: Record<string, unknown> = {
+      contents: [{ parts: [{ text: prompt }] }],
+      generationConfig: { temperature: 0.8, maxOutputTokens: 4096 },
+    }
+    if (useSearch) body.tools = [{ google_search: {} }]
     const res = await fetch(`${GEMINI_URL}?key=${GEMINI_API_KEY}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        contents: [{ parts: [{ text: prompt }] }],
-        generationConfig: { temperature: 0.8, maxOutputTokens: 4096 },
-      }),
-      signal: AbortSignal.timeout(20000),
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(15000),
     })
     if (!res.ok) return null
     const data = await res.json()
@@ -55,8 +58,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const today = new Date().toISOString().split('T')[0]
   if (cache?.date === today) return res.status(200).json(cache.data)
 
-  // 1. Generate question
-  const qRaw = await callGemini(QUESTION_PROMPT)
+  // 1. Generate question (Google Search Grounding으로 실시간 뉴스 기반)
+  const qRaw = await callGemini(buildQuestionPrompt(today), true)
   let question = qRaw ? parseJson(qRaw) as { title: string; question: string; category: string } | null : null
 
   if (!question) {


### PR DESCRIPTION
## Summary
- `callGemini`에 `useSearch` 파라미터 추가 → `tools: [{ google_search: {} }]` 활성화
- `buildQuestionPrompt(today)` 함수로 오늘 날짜 주입, 실제 뉴스 기반 질문 생성 유도
- 질문 생성 호출에만 grounding 적용 (캐릭터 예측은 context 충분 → 검색 불필요)
- 타임아웃 20s → 15s (CLAUDE.md API 원칙 준수)
- 폴백 로직 유지 (API 실패 시 기본 질문/캐릭터 데이터)

## Test plan
- [x] TypeScript 에러 0개 (`tsc --noEmit`)
- [x] 유닛 테스트 35개 통과
- [ ] Vercel Preview에서 `/api/question` 응답 확인 — 오늘 날짜 뉴스 기반 질문 생성 여부

## 역할 리뷰
**볼트 (BE)** — API 변경, 보안 검토 필요

Closes #41

🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 실시간 뉴스 데이터를 기반으로 한 질문 생성 기능 추가
  * Google 검색 연동으로 최신 정보에 기반한 더욱 정확한 질문 생성

* **성능 개선**
  * 요청 처리 속도 향상으로 더 빠른 응답 시간 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->