### PR TITLE
feat: Lighthouse CI 자동 측정 설정 (#55)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: quality
     if: github.event_name == 'pull_request'
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
 

--- a/.lighthouserc.json
+++ b/.lighthouserc.json
@@ -10,7 +10,6 @@
       }
     },
     "assert": {
-      "preset": "lighthouse:no-pwa",
       "assertions": {
         "categories:performance": ["warn", { "minScore": 0.85 }],
         "categories:accessibility": ["warn", { "minScore": 0.85 }],


### PR DESCRIPTION
## Summary
- `.lighthouserc.json` 추가: LCP ≤2.5s, CLS ≤0.1, TBT ≤300ms 기준
- `.github/workflows/ci.yml`: PR 트리거 시 quality job 통과 후 Lighthouse 자동 실행
- `warn` 수준으로 설정 — CI 블로킹 없이 점수 리포트 확인 후 기준선 상향 예정

## Test plan
- [ ] PR 생성 시 Lighthouse CI 잡 트리거 확인
- [ ] temporary-public-storage에 리포트 업로드 확인
- [ ] 성능/접근성/SEO 점수 최초 측정값 확인 후 quality-baseline.md 갱신

Closes #55

🤖 Generated by Claude Code [claude-sonnet-4-6]