### PR TITLE
ux: CharacterCard reasoning 미리보기 + 애니메이션 (#57)

### DIFF
--- a/src/components/vote/CharacterCard.module.css
+++ b/src/components/vote/CharacterCard.module.css
@@ -67,11 +67,32 @@
   color: var(--color-text-tertiary);
 }
 
+.reasoningWrap {
+  margin-top: 8px;
+  padding-top: 8px;
+  border-top: 1px solid var(--color-border);
+  overflow: hidden;
+  max-height: 1.6em;
+  transition: max-height 0.25s ease;
+}
+
+.reasoningWrap.expanded {
+  max-height: 200px;
+}
+
 .reasoning {
-  margin-top: 10px;
   font-size: 13px;
   line-height: 1.6;
   color: var(--color-text-secondary);
-  padding-top: 10px;
-  border-top: 1px solid var(--color-border);
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.reasoningWrap:not(.expanded) .reasoning {
+  -webkit-line-clamp: 1;
+}
+
+.reasoningWrap.expanded .reasoning {
+  -webkit-line-clamp: unset;
 }

--- a/src/components/vote/CharacterCard.tsx
+++ b/src/components/vote/CharacterCard.tsx
@@ -57,9 +57,9 @@ export function CharacterCard({ prediction, isCorrect, showCorrect = false }: Pr
         </div>
       </div>
 
-      {expanded && (
+      <div className={`${styles.reasoningWrap} ${expanded ? styles.expanded : ''}`}>
         <p className={styles.reasoning}>{prediction.reasoning}</p>
-      )}
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- collapsed 상태에서 reasoning 첫 줄 미리보기 (1줄, 말줄임표) — 클릭 유도 강화
- expanded 상태에서 전체 텍스트 표시
- `max-height` CSS transition 0.25s — 부드러운 아코디언 애니메이션

## 배경
ADR-009 인사이트 고도화로 reasoning이 2~3문장으로 길어짐. 피카 팀미팅(2026-03-25) 제안.

## Test plan
- [ ] CharacterCard 클릭 시 reasoning 펼치기/접기 동작 확인
- [ ] 접힌 상태에서 첫 줄 미리보기(말줄임표) 확인
- [ ] 펼쳤을 때 전체 텍스트 + 부드러운 애니메이션 확인

Closes #57

🤖 Generated by Claude Code [claude-sonnet-4-6]