### PR TITLE
ux: CharacterCard aria-label 제거 — WCAG 2.5.3 준수 (#62)

### DIFF
--- a/src/components/vote/CharacterCard.tsx
+++ b/src/components/vote/CharacterCard.tsx
@@ -30,7 +30,6 @@ export function CharacterCard({ prediction, isCorrect, showCorrect = false }: Pr
       role="button"
       tabIndex={0}
       aria-expanded={expanded}
-      aria-label={`${prediction.name} 예측 ${expanded ? '접기' : '펼치기'}`}
       onClick={() => setExpanded((v) => !v)}
       onKeyDown={(e) => e.key === 'Enter' && setExpanded((v) => !v)}
     >


### PR DESCRIPTION
## Summary
CharacterCard의 `aria-label`이 가시 텍스트(methodology, badge 등)를 포함하지 않아 Lighthouse `label-content-name-mismatch` 위반 감지. aria-label 제거 — visible content가 accessible name 역할을 함. `aria-expanded` 유지로 상태는 계속 전달됨.

## Test plan
- [ ] CharacterCard 키보드 탐색 (Tab + Enter) 동작 확인
- [ ] 스크린리더에서 카드 내용 읽힘 확인 (VoiceOver/TalkBack)

Closes #62

🤖 Generated by Claude Code [claude-sonnet-4-6]