### PR TITLE
perf: WeeklyPicksSection lazy load — TBT 개선

### DIFF
--- a/src/pages/VotePage.tsx
+++ b/src/pages/VotePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from 'react'
+import { lazy, Suspense, useState, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { TdsButton as Button } from '@/components/shared/TdsButton'
 import { generateVoteShareText, shareText } from '@/lib/utils/share'
@@ -9,7 +9,10 @@ import { EmptyState } from '@/components/shared/EmptyState'
 import { SuccessAnimation } from '@/components/shared/SuccessAnimation'
 import { CharacterCard } from '@/components/vote/CharacterCard'
 import { CrowdBar } from '@/components/vote/CrowdBar'
-import { WeeklyPicksSection } from '@/components/vote/WeeklyPicksSection'
+
+const WeeklyPicksSection = lazy(() =>
+  import('@/components/vote/WeeklyPicksSection').then((m) => ({ default: m.WeeklyPicksSection }))
+)
 import { MOCK_TODAY_QUESTION, MOCK_CHARACTER_PREDICTIONS, MOCK_CROWD_RESULT } from '@/lib/mockData'
 import type { VoteChoice } from '@/types/vote'
 import styles from './VotePage.module.css'
@@ -150,7 +153,9 @@ export function VotePage() {
         </div>
       </section>
 
-      <WeeklyPicksSection />
+      <Suspense>
+        <WeeklyPicksSection />
+      </Suspense>
       {shareMsg && <div className={styles.toast}>{shareMsg}</div>}
       <Disclaimer />
     </div>


### PR DESCRIPTION
## Summary

- `WeeklyPicksSection`을 `React.lazy` + `Suspense`로 분리
- 메인 번들 193KB → 191KB, WeeklyPicksSection 별도 청크(2.3KB) 분리
- VotePage 초기 렌더 범위 축소 → TBT 단축 기대 (현재 543ms → 목표 ≤300ms)

## 번들 변화

| 파일 | 이전 | 이후 |
|------|------|------|
| index.js (main) | 193KB | 191KB |
| WeeklyPicksSection.js (lazy) | — | 2.3KB |

## Test plan

- [ ] VotePage 정상 렌더링, WeeklyPicksSection Suspense 후 노출
- [ ] TypeScript 에러 0개, 42개 테스트 통과
- [ ] Lighthouse CI TBT 개선 확인

Closes #68

🤖 Generated by Claude Code [claude-sonnet-4-6]