### PR TITLE
test: API client 유닛 테스트 추가 — fetch 모킹 9개 케이스 (#86)

### DIFF
--- a/src/lib/api/__tests__/client.test.ts
+++ b/src/lib/api/__tests__/client.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { api } from '../client'
+
+const mockFetch = vi.fn()
+vi.stubGlobal('fetch', mockFetch)
+
+function mockOk(data: unknown) {
+  mockFetch.mockResolvedValueOnce({
+    ok: true,
+    json: () => Promise.resolve(data),
+  })
+}
+
+function mockError(status: number, body: unknown = {}) {
+  mockFetch.mockResolvedValueOnce({
+    ok: false,
+    status,
+    json: () => Promise.resolve(body),
+  })
+}
+
+beforeEach(() => {
+  mockFetch.mockReset()
+})
+
+describe('api.getQuestion', () => {
+  it('성공 시 data 반환', async () => {
+    const question = { id: 'q-2026-03-25', title: '삼성전자 실적', category: '종목' }
+    mockOk(question)
+    const result = await api.getQuestion()
+    expect(result.data).toEqual(question)
+    expect(result.error).toBeUndefined()
+  })
+
+  it('HTTP 에러 시 error 반환', async () => {
+    mockError(500, { error: 'Internal Server Error' })
+    const result = await api.getQuestion()
+    expect(result.error).toBe('Internal Server Error')
+    expect(result.data).toBeUndefined()
+  })
+
+  it('네트워크 에러 시 error 반환', async () => {
+    mockFetch.mockRejectedValueOnce(new Error('Network error'))
+    const result = await api.getQuestion()
+    expect(result.error).toBe('Network error')
+  })
+})
+
+describe('api.vote', () => {
+  it('성공 시 군중 비율 반환', async () => {
+    const crowd = { bullish: 60, bearish: 25, neutral: 15, totalVotes: 1234 }
+    mockOk({ ok: true, crowd })
+    const result = await api.vote({ questionId: 'q-2026-03-25', vote: 'bullish' })
+    expect(result.data?.crowd).toEqual(crowd)
+    expect(result.error).toBeUndefined()
+  })
+
+  it('POST 메서드로 호출', async () => {
+    mockOk({ ok: true, crowd: { bullish: 50, bearish: 30, neutral: 20, totalVotes: 100 } })
+    await api.vote({ questionId: 'q-test', vote: 'bearish', userId: 'user-1' })
+    expect(mockFetch).toHaveBeenCalledWith(
+      expect.stringContaining('/vote'),
+      expect.objectContaining({ method: 'POST' }),
+    )
+  })
+
+  it('HTTP 에러 시 error 반환', async () => {
+    mockError(400, { error: '이미 투표함' })
+    const result = await api.vote({ questionId: 'q-test', vote: 'bullish' })
+    expect(result.error).toBe('이미 투표함')
+  })
+})
+
+describe('api.getResult', () => {
+  it('결과 있을 때 data 반환', async () => {
+    const voteResult = { questionId: 'q-2026-03-24', outcome: 'bullish', crowdCorrect: true }
+    mockOk(voteResult)
+    const result = await api.getResult()
+    expect(result.data).toEqual(voteResult)
+  })
+
+  it('결과 없을 때 null data 반환', async () => {
+    mockOk(null)
+    const result = await api.getResult()
+    expect(result.data).toBeNull()
+    expect(result.error).toBeUndefined()
+  })
+
+  it('에러 시 error 반환', async () => {
+    mockError(503, {})
+    const result = await api.getResult()
+    expect(result.error).toBe('HTTP 503')
+  })
+})


### PR DESCRIPTION
## 변경 사항

`src/lib/api/client.ts`(VotePage/ResultPage 핵심 의존성)에 테스트 커버리지 추가.

### 추가된 테스트 (9개)

| 함수 | 케이스 |
|------|--------|
| `getQuestion()` | 성공, HTTP 에러, 네트워크 에러 |
| `vote()` | 성공 + 군중 비율 반환, POST 메서드 확인, HTTP 에러 |
| `getResult()` | 결과 있음, null 반환, 503 에러 |

유닛 테스트: **51 → 60개**

Closes #86

## [역할 리뷰]
- **호크(QA)** 판정: 승인 — 핵심 API 경로 성공/에러 모두 커버, fetch 모킹 격리됨

🤖 Generated by Claude Code [claude-sonnet-4-6]