### PR TITLE
fix: CrowdBar 시각 바 aria-hidden + role=img (#92)

### DIFF
--- a/src/components/vote/CrowdBar.tsx
+++ b/src/components/vote/CrowdBar.tsx
@@ -15,18 +15,25 @@ export function CrowdBar({ result, animated = true }: Props) {
         토스 유저 <b>{totalVotes.toLocaleString()}명</b> 투표
       </div>
 
-      <div className={styles.barWrap}>
+      <div
+        className={styles.barWrap}
+        role="img"
+        aria-label={`호재 ${bullish}%, 글쎄 ${neutral}%, 악재 ${bearish}%`}
+      >
         <div
           className={`${styles.segment} ${styles.bullish} ${animated ? styles.animated : ''}`}
           style={{ width: `${bullish}%` }}
+          aria-hidden="true"
         />
         <div
           className={`${styles.segment} ${styles.neutral} ${animated ? styles.animated : ''}`}
           style={{ width: `${neutral}%` }}
+          aria-hidden="true"
         />
         <div
           className={`${styles.segment} ${styles.bearish} ${animated ? styles.animated : ''}`}
           style={{ width: `${bearish}%` }}
+          aria-hidden="true"
         />
       </div>
 


### PR DESCRIPTION
## Summary
- 순수 장식용 bar segment div 3개에 `aria-hidden="true"` 추가 — 스크린 리더 빈 요소 읽힘 방지
- `barWrap`에 `role="img"` + `aria-label="호재 X%, 글쎄 X%, 악재 X%"` 추가 — 분포 요약 제공

## Test plan
- [ ] TypeScript 0 errors ✅
- [ ] 스크린 리더에서 barWrap을 이미지로 읽고 legend 텍스트와 중복 없음
- [ ] 기존 렌더링/애니메이션 변화 없음

Closes #92

🤖 Generated by Claude Code [claude-sonnet-4-6]