### PR TITLE
feat: 이번 주 추천픽 — 전문가 추천픽 탭 신설

### DIFF
--- a/api/weekly-picks.ts
+++ b/api/weekly-picks.ts
@@ -47,6 +47,28 @@ const FALLBACK_PICKS = [
   { ticker: '051910', name: 'LG화학', trend: '하락', summary: '배터리 소재 마진 압박 지속. 전기차 수요 둔화 우려 반영.', sentiment: 'negative' },
 ]
 
+const FALLBACK_CHARACTER_PICKS = [
+  { character: 'quant', name: '밸류김', emoji: '💼', ticker: '005930', stockName: '삼성전자', reason: 'PER 10.8배로 섹터 평균 대비 24% 할인. 기관 순매수 5거래일 연속 지속.' },
+  { character: 'professor', name: '팩터박', emoji: '📚', ticker: '000660', stockName: 'SK하이닉스', reason: 'Fama-French(1993) Size+Value Factor 동시 충족. Momentum 상위 20% 진입.' },
+  { character: 'reporter', name: '뉴스최', emoji: '📺', ticker: '207940', stockName: '삼성바이오로직스', reason: '이번 주 CMO 관련 긍정 기사 비율 81%. 외국인 순매수 전환 3일째.' },
+  { character: 'pattern', name: '봉준선', emoji: '📐', ticker: '035420', stockName: 'NAVER', reason: 'RSI 42 — 과매도 탈출 직전. 20일선 지지 확인, 컵앤핸들 패턴 형성 중.' },
+  { character: 'chimp', name: '코인토', emoji: '🎲', ticker: '035720', stockName: '카카오', reason: '오늘 카카오톡 답장이 빠르게 왔어요. 뭔가 좋은 신호인 것 같아요 🎲' },
+]
+
+const CHARACTER_PICKS_PROMPT = (today: string) =>
+  `오늘(${today}) 기준, 방구석 투자 전문가 5명이 각자의 방식으로 이번 주 가장 주목하는 국내 주식 1종목씩 추천합니다.
+
+각 캐릭터의 추천 방식:
+- 밸류김(quant): 이번 주 PER/PBR이 저평가된 종목 — 수치 근거 한 문장
+- 팩터박(professor): 이번 주 학술 팩터(가치/모멘텀/퀄리티) 신호가 강한 종목 — 이론명 포함
+- 뉴스최(reporter): 이번 주 긍정 뉴스 센티멘트가 급상승한 종목 — 센티멘트 수치 포함
+- 봉준선(pattern): 이번 주 기술적 매수 신호가 나타난 종목 — RSI/MACD/패턴 포함
+- 코인토(chimp): 이번 주 완전 감으로 찍은 종목 — 황당한 일상 에피소드 이유 포함 🎲
+
+규칙: 5명이 서로 다른 종목 추천. 투자 자문 아님. 암호화폐 제외.
+JSON 배열로만 응답:
+[{"character":"quant","name":"밸류김","emoji":"💼","ticker":"종목코드6자리","stockName":"종목명","reason":"추천 이유 한 문장"},...]`
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
 
@@ -54,18 +76,25 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (cache?.week === week) return res.status(200).json(cache.data)
 
   const today = new Date().toISOString().split('T')[0]
-  const prompt = `오늘(${today}) 기준 이번 주 국내 주식 시장에서 주목받고 있는 종목 5개를 실제 최신 뉴스를 검색하여 알려주세요.
-각 종목의 이번 주 주요 동향을 2문장으로 요약해주세요. 종목 코드(6자리), 종목명, 주가 방향(상승/하락/중립), 동향 요약, 긍정/부정/중립 구분을 포함하세요.
-투자 자문이 아닌 시장 동향 정보 제공 목적입니다. 암호화폐 제외.
-JSON 배열로만 응답: [{"ticker":"종목코드","name":"종목명","trend":"상승|하락|중립","summary":"동향 2문장","sentiment":"positive|negative|neutral"}]`
 
-  const raw = await callGeminiSearch(prompt)
-  const picks = raw ? parseJson(raw) : null
+  // 두 Gemini 호출 병렬 실행
+  const [picksRaw, charPicksRaw] = await Promise.all([
+    callGeminiSearch(
+      `오늘(${today}) 기준 이번 주 국내 주식 시장에서 주목받고 있는 종목 5개를 실제 최신 뉴스를 검색하여 알려주세요.
+각 종목의 이번 주 주요 동향을 2문장으로 요약해주세요. 투자 자문이 아닌 시장 동향 정보 제공 목적입니다. 암호화폐 제외.
+JSON 배열로만 응답: [{"ticker":"종목코드","name":"종목명","trend":"상승|하락|중립","summary":"동향 2문장","sentiment":"positive|negative|neutral"}]`
+    ),
+    callGeminiSearch(CHARACTER_PICKS_PROMPT(today)),
+  ])
+
+  const picks = picksRaw ? parseJson(picksRaw) : null
+  const charPicks = charPicksRaw ? parseJson(charPicksRaw) : null
 
   const data = {
     week,
     generatedAt: new Date().toISOString(),
     picks: Array.isArray(picks) && picks.length >= 3 ? picks : FALLBACK_PICKS,
+    characterPicks: Array.isArray(charPicks) && charPicks.length >= 5 ? charPicks : FALLBACK_CHARACTER_PICKS,
     disclaimer: '이 정보는 투자 자문이 아닌 시장 동향 참고용입니다.',
   }
 

--- a/src/components/vote/WeeklyPicksSection.module.css
+++ b/src/components/vote/WeeklyPicksSection.module.css
@@ -99,3 +99,63 @@
   line-height: 1.5;
   margin: 0;
 }
+
+.tabs {
+  display: flex;
+  gap: 6px;
+  padding: 0 16px 10px;
+}
+
+.tabBtn {
+  padding: 5px 14px;
+  border-radius: 20px;
+  border: 1px solid var(--color-border);
+  background: none;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--color-text-tertiary);
+  cursor: pointer;
+  transition: all 0.15s;
+}
+
+.tabActive {
+  background: var(--color-primary);
+  border-color: var(--color-primary);
+  color: #fff;
+}
+
+.expertCard {
+  background: #f5f0ff;
+  border-color: #d4b8ff;
+}
+
+.expertHeader {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.expertEmoji {
+  font-size: 18px;
+  line-height: 1;
+}
+
+.expertName {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.expertStock {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--color-text);
+  margin-bottom: 2px;
+}
+
+.expertTicker {
+  font-size: var(--font-size-caption);
+  color: var(--color-text-tertiary);
+  margin-bottom: 6px;
+}

--- a/src/components/vote/WeeklyPicksSection.tsx
+++ b/src/components/vote/WeeklyPicksSection.tsx
@@ -9,6 +9,15 @@ interface Pick {
   sentiment: 'positive' | 'negative' | 'neutral'
 }
 
+interface CharacterPick {
+  character: string
+  name: string
+  emoji: string
+  ticker: string
+  stockName: string
+  reason: string
+}
+
 const FALLBACK_PICKS: Pick[] = [
   { ticker: '005930', name: '삼성전자', trend: '상승', summary: 'HBM 수주 증가 기대감. 기관 순매수 지속.', sentiment: 'positive' },
   { ticker: '000660', name: 'SK하이닉스', trend: '상승', summary: 'AI 서버 DRAM 수요 급증. 엔비디아 공급망 핵심.', sentiment: 'positive' },
@@ -17,17 +26,31 @@ const FALLBACK_PICKS: Pick[] = [
   { ticker: '051910', name: 'LG화학', trend: '하락', summary: '배터리 소재 마진 압박 지속.', sentiment: 'negative' },
 ]
 
+const FALLBACK_CHARACTER_PICKS: CharacterPick[] = [
+  { character: 'quant', name: '밸류김', emoji: '💼', ticker: '005930', stockName: '삼성전자', reason: 'PER 10.8배로 섹터 평균 대비 24% 할인. 기관 순매수 5거래일 연속 지속.' },
+  { character: 'professor', name: '팩터박', emoji: '📚', ticker: '000660', stockName: 'SK하이닉스', reason: 'Fama-French(1993) Size+Value Factor 동시 충족. Momentum 상위 20% 진입.' },
+  { character: 'reporter', name: '뉴스최', emoji: '📺', ticker: '207940', stockName: '삼성바이오로직스', reason: '이번 주 CMO 관련 긍정 기사 비율 81%. 외국인 순매수 전환 3일째.' },
+  { character: 'pattern', name: '봉준선', emoji: '📐', ticker: '035420', stockName: 'NAVER', reason: 'RSI 42 — 과매도 탈출 직전. 컵앤핸들 패턴 형성 중.' },
+  { character: 'chimp', name: '코인토', emoji: '🎲', ticker: '035720', stockName: '카카오', reason: '오늘 카카오톡 답장이 빠르게 왔어요. 뭔가 좋은 신호인 것 같아요 🎲' },
+]
+
 const TREND_EMOJI: Record<string, string> = { 상승: '📈', 하락: '📉', 중립: '➡️' }
-const SENTIMENT_COLOR: Record<string, string> = { positive: 'positive', negative: 'negative', neutral: 'neutral' }
+
+type Tab = 'market' | 'expert'
 
 export function WeeklyPicksSection() {
   const [picks, setPicks] = useState<Pick[]>(FALLBACK_PICKS)
+  const [characterPicks, setCharacterPicks] = useState<CharacterPick[]>(FALLBACK_CHARACTER_PICKS)
   const [loading, setLoading] = useState(true)
+  const [tab, setTab] = useState<Tab>('market')
 
   useEffect(() => {
     fetch('/api/weekly-picks')
       .then((r) => r.json())
-      .then((d) => { if (Array.isArray(d.picks)) setPicks(d.picks) })
+      .then((d) => {
+        if (Array.isArray(d.picks)) setPicks(d.picks)
+        if (Array.isArray(d.characterPicks)) setCharacterPicks(d.characterPicks)
+      })
       .catch(() => {})
       .finally(() => setLoading(false))
   }, [])
@@ -35,24 +58,52 @@ export function WeeklyPicksSection() {
   return (
     <section className={styles.section}>
       <div className={styles.header}>
-        <span className={styles.title}>이번 주 주목 동향</span>
+        <span className={styles.title}>이번 주 주목</span>
         <span className={styles.disclaimer}>투자 자문 아님</span>
       </div>
+
+      <div className={styles.tabs}>
+        <button
+          className={`${styles.tabBtn} ${tab === 'market' ? styles.tabActive : ''}`}
+          onClick={() => setTab('market')}
+        >
+          시장 동향
+        </button>
+        <button
+          className={`${styles.tabBtn} ${tab === 'expert' ? styles.tabActive : ''}`}
+          onClick={() => setTab('expert')}
+        >
+          전문가 추천픽
+        </button>
+      </div>
+
       <div className={styles.scroll}>
         {loading
           ? Array.from({ length: 3 }).map((_, i) => (
               <div key={i} className={`${styles.card} ${styles.skeleton}`} />
             ))
-          : picks.map((pick) => (
-              <div key={pick.ticker} className={`${styles.card} ${styles[SENTIMENT_COLOR[pick.sentiment]]}`}>
-                <div className={styles.cardHeader}>
-                  <span className={styles.ticker}>{pick.ticker}</span>
-                  <span className={styles.trend}>{TREND_EMOJI[pick.trend]} {pick.trend}</span>
+          : tab === 'market'
+            ? picks.map((pick) => (
+                <div key={pick.ticker} className={`${styles.card} ${styles[pick.sentiment]}`}>
+                  <div className={styles.cardHeader}>
+                    <span className={styles.ticker}>{pick.ticker}</span>
+                    <span className={styles.trend}>{TREND_EMOJI[pick.trend]} {pick.trend}</span>
+                  </div>
+                  <div className={styles.name}>{pick.name}</div>
+                  <p className={styles.summary}>{pick.summary}</p>
                 </div>
-                <div className={styles.name}>{pick.name}</div>
-                <p className={styles.summary}>{pick.summary}</p>
-              </div>
-            ))}
+              ))
+            : characterPicks.map((cp) => (
+                <div key={cp.character} className={`${styles.card} ${styles.expertCard}`}>
+                  <div className={styles.expertHeader}>
+                    <span className={styles.expertEmoji}>{cp.emoji}</span>
+                    <span className={styles.expertName}>{cp.name}</span>
+                  </div>
+                  <div className={styles.expertStock}>{cp.stockName}</div>
+                  <div className={styles.expertTicker}>{cp.ticker}</div>
+                  <p className={styles.summary}>{cp.reason}</p>
+                </div>
+              ))}
       </div>
     </section>
   )


### PR DESCRIPTION
## Summary

- WeeklyPicksSection에 **시장 동향 / 전문가 추천픽** 탭 전환 UI 추가
- 투표 종목과 완전히 독립된 별도 컨텐츠: 5명 캐릭터가 각자 이번 주 주목 종목 1개씩 추천
- `/api/weekly-picks` — `characterPicks` 필드 추가, Gemini 2회 병렬 호출

## CEO 피드백 반영 (#3)

"이번 주 추천픽 섹션 신설 — 투표 종목 외 별도 컨텐츠"

| 탭 | 내용 |
|----|------|
| 시장 동향 | 기존 이번 주 주목 종목 5개 (trend + summary) |
| 전문가 추천픽 | 밸류김/팩터박/뉴스최/봉준선/코인토 각 1종목 + 분석 이유 |

## Test plan

- [ ] `pnpm build` 통과 ✅ (19.42KB JS, 0 TS 에러)
- [ ] WeeklyPicksSection 탭 전환 동작 확인
- [ ] 전문가 추천픽 탭 — 5명 카드 렌더링 확인
- [ ] 폴백 데이터 표시 확인 (API 없는 환경)
- [ ] `/api/weekly-picks` 응답에 `characterPicks` 배열 포함 확인

Closes #102

🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 전문가 추천 섹션 추가: 캐릭터 기반의 맞춤형 주식 추천 정보 제공 (이모지, 이름, 종목명, 티커, 추천 이유 포함)
* 탭 기반 UI 도입: "시장 동향"과 "전문가 추천픽" 사이를 간편하게 전환 가능
* 향상된 성능: 두 가지 추천 데이터를 동시에 로드하여 더 빠른 화면 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->