### PR TITLE
feat: ResultPage 전면 광고 게이팅 (Issue #108)

### DIFF
--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { showInterstitialAd } from '@/lib/bedrock'
 import { TdsButton as Button } from '@/components/shared/TdsButton'
 import { TdsBadge as Badge } from '@/components/shared/TdsBadge'
 import { Disclaimer } from '@/components/shared/Disclaimer'
@@ -19,9 +20,18 @@ const OUTCOME_COLORS = {
   neutral: 'yellow',
 } as const
 
+const AD_SESSION_KEY = 'sp_interstitial_shown'
+
 export function ResultPage() {
   const navigate = useNavigate()
   const [result, setResult] = useState<VoteResult | null | undefined>(undefined)
+
+  useEffect(() => {
+    if (!sessionStorage.getItem(AD_SESSION_KEY)) {
+      sessionStorage.setItem(AD_SESSION_KEY, 'true')
+      showInterstitialAd()
+    }
+  }, [])
 
   useEffect(() => {
     api.getResult().then(({ data }) => {


### PR DESCRIPTION
## Summary
- ResultPage 진입 시 세션 당 1회 전면광고(interstitial) 노출
- `sessionStorage` 키 `sp_interstitial_shown`으로 중복 노출 방지
- 광고 로딩과 결과 데이터 로딩은 독립적으로 병렬 실행

## 변경 파일
- `src/pages/ResultPage.tsx` — `showInterstitialAd` import + useEffect 추가

## Test plan
- [ ] ResultPage 첫 방문 시 interstitial 광고 호출됨
- [ ] 같은 세션에서 재방문 시 광고 미노출 (sessionStorage 키 확인)
- [ ] 광고 호출과 무관하게 결과 데이터 정상 로드됨
- [ ] 빌드 통과, 유닛 60개 통과

**[역할 리뷰]** 판정: 호크 (QA) 승인 요청 — 세션 광고 게이팅 로직, E2E 엣지 케이스 확인 필요

🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 결과 페이지에서 세션당 한 번의 중간 광고 표시가 추가되었습니다. 브라우저 세션이 시작될 때 처음으로 결과 페이지에 접속하면 광고가 자동으로 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->