### PR TITLE
fix: VotePage 접근성 — toast aria-live + 화살표 aria-hidden (#112)

### DIFF
--- a/src/pages/VotePage.tsx
+++ b/src/pages/VotePage.tsx
@@ -117,7 +117,7 @@ export function VotePage() {
       <button className={styles.resultBanner} onClick={() => navigate('/result')}>
         <Badge size="xsmall" variant="fill" color="red">NEW</Badge>
         <span className={styles.resultText}>어제 질문 결과가 나왔어요!</span>
-        <span>→</span>
+        <span aria-hidden="true">→</span>
       </button>
 
       {/* Question card */}
@@ -186,7 +186,7 @@ export function VotePage() {
       <Suspense>
         <WeeklyPicksSection />
       </Suspense>
-      {shareMsg && <div className={styles.toast}>{shareMsg}</div>}
+      {shareMsg && <div role="status" aria-live="polite" className={styles.toast}>{shareMsg}</div>}
       <Disclaimer />
     </div>
   )


### PR DESCRIPTION
## Summary
스크린리더 지원 2건 개선. Lighthouse Accessibility 점수 향상 기여.

- `toast` div — `role="status"` + `aria-live="polite"` 추가
  - 공유 성공 시 '클립보드에 복사됨!' 메시지를 스크린리더가 자동으로 읽음
- resultBanner `→` span — `aria-hidden="true"` 추가
  - 장식용 화살표를 스크린리더가 건너뜀

## Test plan
- [ ] TS 0 에러, 유닛 60개 통과
- [ ] 스크린리더(VoiceOver) 공유 버튼 클릭 → "클립보드에 복사됨" 알림 확인
- [ ] 결과 배너 이동 버튼 읽기 시 화살표 문자 제외 확인

**[역할 리뷰]** 판정: 피카 (디자이너) 승인 요청 — WCAG 2.1 AA 기준 검토

🤖 Generated by Claude Code [claude-sonnet-4-6]