### PR TITLE
fix: CharacterCard Space 키 처리 — WCAG 2.1.1 준수 (#114)

### DIFF
--- a/src/components/vote/CharacterCard.tsx
+++ b/src/components/vote/CharacterCard.tsx
@@ -31,7 +31,7 @@ export function CharacterCard({ prediction, isCorrect, showCorrect = false }: Pr
       tabIndex={0}
       aria-expanded={expanded}
       onClick={() => setExpanded((v) => !v)}
-      onKeyDown={(e) => e.key === 'Enter' && setExpanded((v) => !v)}
+      onKeyDown={(e) => (e.key === 'Enter' || e.key === ' ') && setExpanded((v) => !v)}
     >
       <div className={styles.header}>
         <div className={styles.identity}>


### PR DESCRIPTION
## Summary
`role="button"` 요소는 WCAG 2.1.1에 따라 Enter와 Space 키를 모두 처리해야 함. 기존 코드는 Enter만 처리했음.

**변경:** `e.key === 'Enter'` → `e.key === 'Enter' || e.key === ' '`

## Test plan
- [ ] TS 0 에러, 유닛 60개 통과
- [ ] Space 키로 CharacterCard 펼치기/접기 동작 확인
- [ ] Enter 키 기존 동작 유지 확인

**[역할 리뷰]** 판정: 피카 (디자이너) 승인 요청 — WCAG 2.1.1 키보드 접근성 검토

🤖 Generated by Claude Code [claude-sonnet-4-6]