### PR TITLE
fix: Onboarding 접근성 — role=dialog + aria-modal + dots 위치 공지 (#118)

### DIFF
--- a/src/components/shared/Onboarding.tsx
+++ b/src/components/shared/Onboarding.tsx
@@ -29,13 +29,17 @@ export function Onboarding({ onComplete }: Props) {
   const isLast = current === SLIDES.length - 1
 
   return (
-    <div className={styles.overlay}>
+    <div className={styles.overlay} role="dialog" aria-modal="true" aria-labelledby="onboarding-title">
       <div className={styles.content}>
-        <span className={styles.emoji}>{slide.emoji}</span>
-        <h2 className={styles.title}>{slide.title}</h2>
+        <span className={styles.emoji} aria-hidden="true">{slide.emoji}</span>
+        <h2 id="onboarding-title" className={styles.title}>{slide.title}</h2>
         <p className={styles.description}>{slide.description}</p>
 
-        <div className={styles.dots}>
+        <div
+          className={styles.dots}
+          role="status"
+          aria-label={`슬라이드 ${current + 1} / ${SLIDES.length}`}
+        >
           {SLIDES.map((_, i) => (
             <span key={i} className={`${styles.dot} ${i === current ? styles.active : ''}`} />
           ))}


### PR DESCRIPTION
## Summary
Onboarding 모달 WCAG 접근성 개선 4건:

| 항목 | 수정 내용 |
|------|---------|
| overlay div | `role="dialog"` + `aria-modal="true"` + `aria-labelledby="onboarding-title"` |
| h2 | `id="onboarding-title"` 추가 |
| emoji span | `aria-hidden="true"` — ⚡🔮👥 장식 이모지 제외 |
| dots div | `role="status"` + `aria-label="슬라이드 N/3"` |

## Test plan
- [ ] TS 0 에러, 유닛 60개 통과
- [ ] VoiceOver 진입 시 "온보딩, 오늘의 투자 시그널 예측해보세요, 대화상자" 공지 확인
- [ ] '다음' 버튼 클릭 시 "슬라이드 2/3" 공지 확인

**[역할 리뷰]** 판정: 피카 (디자이너) 승인 요청 — 모달 접근성 패턴 검토

🤖 Generated by Claude Code [claude-sonnet-4-6]