### PR TITLE
fix: resultBanner 터치 타겟 min-height 48px — WCAG 2.5.5 (#124)

### DIFF
--- a/src/pages/VotePage.module.css
+++ b/src/pages/VotePage.module.css
@@ -7,6 +7,7 @@
   align-items: center;
   gap: 8px;
   width: 100%;
+  min-height: 48px;
   padding: 12px 16px;
   background: #f0f7ff;
   border: none;


### PR DESCRIPTION
## Summary
VotePage resultBanner 버튼 터치 영역 WCAG 2.5.5 권장(48px) 미달 → 수정.

- `.resultBanner`에 `min-height: 48px` 추가
- CSS 9.33→9.34KB (+0.01KB, baseline 이내)

## Test plan
- [ ] 빌드 통과, 유닛 60개 통과
- [ ] resultBanner 터치 영역 48px 확보 확인

**[역할 리뷰]** 판정: 피카 (디자이너) 승인 요청 — 터치 타겟 UI 영향 확인

🤖 Generated by Claude Code [claude-sonnet-4-6]