### PR TITLE
fix: P1 E2E 래칫 위반 복구 — 온보딩 슬라이드 E2E (#126)

### DIFF
--- a/e2e/onboarding.spec.ts
+++ b/e2e/onboarding.spec.ts
@@ -1,0 +1,27 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('온보딩', () => {
+  test('슬라이드 3장 완료 → 투표 페이지 진입', async ({ page }) => {
+    // 온보딩 기록 삭제 → 항상 온보딩 보이도록
+    await page.addInitScript(() => {
+      localStorage.removeItem('signalplay-onboarded')
+    })
+
+    await page.goto('/')
+
+    // 1번 슬라이드 확인
+    await expect(page.getByText('오늘의 투자 시그널')).toBeVisible({ timeout: 5000 })
+
+    // '다음' 클릭 → 2번 슬라이드
+    await page.getByRole('button', { name: '다음' }).click()
+    await expect(page.getByText('방구석 전문가 5명')).toBeVisible()
+
+    // '다음' 클릭 → 3번 슬라이드
+    await page.getByRole('button', { name: '다음' }).click()
+    await expect(page.getByText('군중과 비교')).toBeVisible()
+
+    // '시작하기' 클릭 → 온보딩 종료, 투표 페이지 진입
+    await page.getByRole('button', { name: '시작하기' }).click()
+    await expect(page.getByRole('button', { name: /호재|악재|글쎄/ }).first()).toBeVisible({ timeout: 10000 })
+  })
+})


### PR DESCRIPTION
## Summary
**P1 긴급:** E2E 테스트 baseline 4개 → 실제 3개 (1개 누락) 래칫 위반 복구.

### 추가된 테스트 (`e2e/onboarding.spec.ts`)
1. localStorage 초기화 → 온보딩 항상 노출
2. 슬라이드 1 ("오늘의 투자 시그널") 확인
3. '다음' × 2 → 슬라이드 2, 3 확인
4. '시작하기' → 투표 페이지 진입, 투표 버튼 표시 확인

### E2E 카운트
4개 복원: vote.spec.ts(2) + result.spec.ts(1) + **onboarding.spec.ts(1)**

## Test plan
- [ ] 유닛 60개 통과
- [ ] Playwright 온보딩 플로우 통과 (dev server 필요)

**[역할 리뷰]** 판정: 호크 (QA) P1 승인 요청 — E2E 래칫 위반 복구

🤖 Generated by Claude Code [claude-sonnet-4-6]