### PR TITLE
fix: E2E vote.spec.ts 캐릭터명 하드코딩 → 이모지 기반 셀렉터 (#128)

### DIFF
--- a/e2e/vote.spec.ts
+++ b/e2e/vote.spec.ts
@@ -13,9 +13,9 @@ test.describe('투표 페이지', () => {
     // 질문이 표시될 때까지 대기
     await expect(page.getByRole('button', { name: /호재/ }).first()).toBeVisible({ timeout: 10000 })
 
-    // 캐릭터 예측이 표시되는지 확인
-    await expect(page.getByText('엑셀형').first()).toBeVisible()
-    await expect(page.getByText('운형').first()).toBeVisible()
+    // 캐릭터 예측이 표시되는지 확인 (이름 변경에 무관한 이모지 기반)
+    await expect(page.getByText('💼').first()).toBeVisible()
+    await expect(page.getByText('🎲').first()).toBeVisible()
 
     // 호재 투표
     await page.getByRole('button', { name: /호재/ }).first().click()


### PR DESCRIPTION
## Summary
- `e2e/vote.spec.ts`의 `엑셀형`/`운형` 하드코딩 → `💼`/`🎲` 이모지 기반으로 교체
- PR #100 (캐릭터 리네이밍 밸류김/코인토) 머지 후에도 E2E 테스트 깨지지 않음

## Test plan
- [ ] 현재 캐릭터명(엑셀형/운형)에서 통과 확인
- [ ] PR #100 머지 후에도 이모지 셀렉터로 통과 확인

Closes #128

🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선 사항**
  * 캐릭터 예측 인터페이스에서 텍스트 레이블을 이모지 기호(💼, 🎲)로 업데이트하여 시각적 명확성과 국제적 접근성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->