### PR TITLE
ux: ResultPage 결과 헤더 최상단 노출 (#132)

### DIFF
--- a/src/pages/ResultPage.module.css
+++ b/src/pages/ResultPage.module.css
@@ -1,5 +1,47 @@
 .page { padding: 0 16px; }
 
+.outcomeHeader {
+  border-radius: 16px;
+  padding: 20px 16px;
+  margin-top: 16px;
+  margin-bottom: 16px;
+  text-align: center;
+}
+
+.outcomeHeaderHit {
+  background: #e6f9f0;
+}
+
+.outcomeHeaderMiss {
+  background: #fff0f0;
+}
+
+.outcomeHeaderTitle {
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  margin-bottom: 12px;
+}
+
+.outcomeHeaderRow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  font-size: 15px;
+  color: var(--color-text);
+  margin-bottom: 10px;
+}
+
+.outcomeArrow {
+  color: var(--color-text-tertiary);
+}
+
+.outcomeVerdict {
+  font-size: 22px;
+  font-weight: 800;
+  color: var(--color-text);
+}
+
 .title {
   font-size: 22px;
   font-weight: 700;

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -62,9 +62,24 @@ export function ResultPage() {
 
   const correctCount = result.characters.filter((c) => c.isCorrect).length
 
+  const isCorrect = myVote?.choice === result.actualOutcome
+
   return (
     <div className={styles.page}>
-      <h1 className={styles.title}>🎯 어제의 결과</h1>
+      {/* 결과 헤더 — 스크롤 없이 3초 내 적중 여부 확인 */}
+      {myVote ? (
+        <div className={`${styles.outcomeHeader} ${isCorrect ? styles.outcomeHeaderHit : styles.outcomeHeaderMiss}`}>
+          <p className={styles.outcomeHeaderTitle}>{result.title}</p>
+          <div className={styles.outcomeHeaderRow}>
+            <span>내 예측 <strong>{OUTCOME_LABELS[myVote.choice]}</strong></span>
+            <span className={styles.outcomeArrow}>→</span>
+            <span>실제 <strong>{OUTCOME_LABELS[result.actualOutcome]}</strong></span>
+          </div>
+          <p className={styles.outcomeVerdict}>{isCorrect ? '✅ 적중!' : '❌ 빗나감'}</p>
+        </div>
+      ) : (
+        <h1 className={styles.title}>🎯 어제의 결과</h1>
+      )}
 
       {/* Question recap */}
       <div className={styles.questionCard}>
@@ -79,19 +94,6 @@ export function ResultPage() {
             {OUTCOME_LABELS[result.actualOutcome]}
           </Badge>
         </div>
-        {myVote && (
-          <div className={styles.outcomeRow}>
-            <span className={styles.outcomeLabel}>내 예측</span>
-            <Badge
-              size="medium"
-              variant="weak"
-              color={OUTCOME_COLORS[myVote.choice]}
-            >
-              {OUTCOME_LABELS[myVote.choice]}
-              {myVote.choice === result.actualOutcome ? ' ✅' : ' ❌'}
-            </Badge>
-          </div>
-        )}
       </div>
 
       {/* Crowd result */}


### PR DESCRIPTION
## Summary
- ResultPage 최상단에 "내 예측 → 실제 결과 ✅ 적중!" 헤더 카드 추가
- 투표 기록 있을 때만 노출, 없으면 기존 타이틀 표시
- 적중 시 연초록 배경, 빗나감 시 연빨강 배경

## Before / After
| Before | After |
|--------|-------|
| 질문카드 안에 배지로 묻혀있음 | 최상단 전체 폭 카드로 즉시 확인 |
| 스크롤 필요 | 진입 즉시 3초 내 확인 |

## 번들 영향
- ResultPage CSS: +0.6KB (기능 추가 정당화, P2)
- 초기 로드 JS: 변화 없음

Closes #132

🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Style**
  * 결과 피드백 헤더의 시각적 스타일을 개선했습니다.

* **Refactor**
  * 결과 화면 레이아웃을 재구성하여 사용자의 예측 결과를 더 명확하게 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->