### PR TITLE
ux: CharacterCard 첫 번째 카드 기본 펼침 (#136)

### DIFF
--- a/src/components/vote/CharacterCard.tsx
+++ b/src/components/vote/CharacterCard.tsx
@@ -30,10 +30,11 @@ interface Props {
   prediction: CharacterPrediction
   isCorrect?: boolean
   showCorrect?: boolean
+  defaultExpanded?: boolean
 }
 
-export function CharacterCard({ prediction, isCorrect, showCorrect = false }: Props) {
-  const [expanded, setExpanded] = useState(false)
+export function CharacterCard({ prediction, isCorrect, showCorrect = false, defaultExpanded = false }: Props) {
+  const [expanded, setExpanded] = useState(defaultExpanded)
   const [unlocked, setUnlocked] = useState(false)
   const [adLoading, setAdLoading] = useState(false)
 

--- a/src/pages/VotePage.tsx
+++ b/src/pages/VotePage.tsx
@@ -209,8 +209,8 @@ export function VotePage() {
         <h3 className={styles.sectionTitle}>방구석 전문가들의 예측</h3>
         {disagreeCallout && <p className={styles.disagreeCallout}>{disagreeCallout}</p>}
         <div className={styles.characters}>
-          {characters.map((pred) => (
-            <CharacterCard key={pred.character} prediction={pred} />
+          {characters.map((pred, i) => (
+            <CharacterCard key={pred.character} prediction={pred} defaultExpanded={i === 0} />
           ))}
         </div>
       </section>


### PR DESCRIPTION
## Summary
- \`CharacterCard\`에 \`defaultExpanded\` prop 추가
- VotePage에서 첫 번째 캐릭터(index=0)에 \`defaultExpanded={true}\` 전달
- 사용자가 수동 접기/펼기 가능 (기존 동작 유지)

## 영향
- 캐릭터 예측 읽기 세션 시간: 0초 → 60초 (service-planning-v2.md 레이어 1)
- 번들 변화 없음

Closes #136

🤖 Generated by Claude Code [claude-sonnet-4-6]