### PR TITLE
ux: CharacterCard 접힘 상태 reasoning 미리보기 — 첫 40자

### DIFF
--- a/src/components/vote/CharacterCard.module.css
+++ b/src/components/vote/CharacterCard.module.css
@@ -67,17 +67,30 @@
   color: var(--color-text-tertiary);
 }
 
+.preview {
+  margin-top: 6px;
+  font-size: var(--font-size-caption);
+  color: var(--color-text-tertiary);
+  line-height: 1.4;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.preview {
+  margin-top: 6px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--color-text-tertiary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 .reasoningWrap {
   margin-top: 8px;
   padding-top: 8px;
   border-top: 1px solid var(--color-border);
-  overflow: hidden;
-  max-height: 1.6em;
-  transition: max-height 0.3s ease;
-}
-
-.reasoningWrap.expanded {
-  max-height: 300px;
 }
 
 /* 게이트: 1.5줄 + 블러 오버레이 */
@@ -109,13 +122,6 @@
   font-size: 13px;
   line-height: 1.6;
   color: var(--color-text-secondary);
-}
-
-.reasoningWrap:not(.expanded) .reasoning {
-  display: -webkit-box;
-  -webkit-line-clamp: 1;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
 }
 
 .unlockBtn {

--- a/src/components/vote/CharacterCard.tsx
+++ b/src/components/vote/CharacterCard.tsx
@@ -81,31 +81,41 @@ export function CharacterCard({ prediction, isCorrect, showCorrect = false }: Pr
         </div>
       </div>
 
-      <div className={`${styles.reasoningWrap} ${expanded ? styles.expanded : ''}`}>
-        <div className={`${styles.reasoningContent} ${expanded && !unlocked ? styles.gated : ''}`}>
-          <p className={styles.reasoning}>{prediction.reasoning}</p>
-          {expanded && !unlocked && <div className={styles.blurOverlay} />}
+      {!expanded && prediction.reasoning && (
+        <p className={styles.preview}>
+          {prediction.reasoning.length > 40
+            ? `${prediction.reasoning.slice(0, 40)}...`
+            : prediction.reasoning}
+        </p>
+      )}
+
+      {expanded && (
+        <div className={`${styles.reasoningWrap} ${styles.expanded}`}>
+          <div className={`${styles.reasoningContent} ${!unlocked ? styles.gated : ''}`}>
+            <p className={styles.reasoning}>{prediction.reasoning}</p>
+            {!unlocked && <div className={styles.blurOverlay} />}
+          </div>
+
+          {!unlocked && (
+            <button
+              className={styles.unlockBtn}
+              onClick={handleUnlock}
+              disabled={adLoading}
+              aria-label="광고 시청 후 전체 분석 보기"
+            >
+              {adLoading ? '광고 로딩 중...' : '🎬 전체 분석 보기'}
+            </button>
+          )}
+
+          {unlocked && showCorrect && isCorrect !== undefined && (
+            <p className={`${styles.reaction} ${isCorrect ? styles.reactionCorrect : styles.reactionWrong}`}>
+              {isCorrect
+                ? CHARACTER_REACTIONS[prediction.character].correct
+                : CHARACTER_REACTIONS[prediction.character].wrong}
+            </p>
+          )}
         </div>
-
-        {expanded && !unlocked && (
-          <button
-            className={styles.unlockBtn}
-            onClick={handleUnlock}
-            disabled={adLoading}
-            aria-label="광고 시청 후 전체 분석 보기"
-          >
-            {adLoading ? '광고 로딩 중...' : '🎬 전체 분석 보기'}
-          </button>
-        )}
-
-        {expanded && unlocked && showCorrect && isCorrect !== undefined && (
-          <p className={`${styles.reaction} ${isCorrect ? styles.reactionCorrect : styles.reactionWrong}`}>
-            {isCorrect
-              ? CHARACTER_REACTIONS[prediction.character].correct
-              : CHARACTER_REACTIONS[prediction.character].wrong}
-          </p>
-        )}
-      </div>
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary

- 접힌 카드에서 reasoning 앞 40자 + '...' 를 3차 텍스트(tertiary)로 표시
- 펼치면 전체 reasoning 노출 (기존 동작 유지)
- CSS line-clamp 방식 → JS 슬라이스 + 전용 `.preview` 스타일로 교체
- reasoning이 40자 이하면 '...' 없이 그대로 표시

## Test plan

- [x] 60 unit tests passing
- [ ] CharacterCard 접힌 상태 → reasoning 앞 40자 + '...' 회색 텍스트 확인
- [ ] CharacterCard 펼친 상태 → preview 숨김, 전체 reasoning 표시 확인
- [ ] reasoning 40자 이하 캐릭터 → '...' 없이 그대로 표시 확인

Closes #152

🤖 Generated by Claude Code [claude-sonnet-4-6]