### PR TITLE
feat: ResultPage 결과 공유 버튼 추가 — 어제의 결과 공유하기

### DIFF
--- a/src/pages/ResultPage.module.css
+++ b/src/pages/ResultPage.module.css
@@ -194,5 +194,20 @@
 .actions {
   display: flex;
   justify-content: center;
+  gap: 8px;
   margin-bottom: 16px;
+}
+
+.toast {
+  position: fixed;
+  bottom: 80px;
+  left: 50%;
+  transform: translateX(-50%);
+  background: rgba(0, 0, 0, 0.75);
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 20px;
+  font-size: var(--font-size-caption);
+  white-space: nowrap;
+  pointer-events: none;
 }

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { showInterstitialAd } from '@/lib/bedrock'
 import { TdsButton as Button } from '@/components/shared/TdsButton'
@@ -9,6 +9,7 @@ import { CharacterCard } from '@/components/vote/CharacterCard'
 import { CrowdBar } from '@/components/vote/CrowdBar'
 import { getVote } from '@/lib/utils/voteHistory'
 import { recordResult, getStreak, getAccuracyPercent } from '@/lib/utils/userStats'
+import { generateResultShareText, shareText } from '@/lib/utils/share'
 import { MOCK_VOTE_RESULT, MOCK_CHARACTER_ACCURACY } from '@/lib/mockData'
 import { api } from '@/lib/api/client'
 import type { VoteResult } from '@/types/vote'
@@ -26,6 +27,7 @@ const AD_SESSION_KEY = 'sp_interstitial_shown'
 export function ResultPage() {
   const navigate = useNavigate()
   const [result, setResult] = useState<VoteResult | null | undefined>(undefined)
+  const [shareMsg, setShareMsg] = useState('')
 
   useEffect(() => {
     if (!sessionStorage.getItem(AD_SESSION_KEY)) {
@@ -47,6 +49,29 @@ export function ResultPage() {
   }, [])
 
   const myVote = result ? getVote(result.questionId) : null
+
+  const handleShare = useCallback(async () => {
+    if (!result) return
+    const crowdWon = result.crowdResult.bullish >= result.crowdResult.bearish &&
+      result.crowdResult.bullish >= result.crowdResult.neutral
+        ? result.actualOutcome === 'bullish'
+        : result.crowdResult.bearish >= result.crowdResult.neutral
+          ? result.actualOutcome === 'bearish'
+          : result.actualOutcome === 'neutral'
+    const vote = getVote(result.questionId)
+    const text = generateResultShareText({
+      title: result.title,
+      crowdCorrect: crowdWon,
+      characters: result.characters.map((c) => ({ emoji: c.emoji, name: c.name, isCorrect: c.isCorrect })),
+      myCorrect: vote ? vote.choice === result.actualOutcome : false,
+      streak: getStreak(),
+    })
+    const res = await shareText(text)
+    if (res === 'copied') {
+      setShareMsg('클립보드에 복사됨!')
+      setTimeout(() => setShareMsg(''), 2000)
+    }
+  }, [result])
 
   if (result === undefined) {
     return (
@@ -190,6 +215,16 @@ export function ResultPage() {
         </div>
       </div>
 
+      <div className={styles.actions}>
+        <Button size="medium" variant="fill" color="primary" onClick={() => navigate('/')}>
+          오늘 투표하기 →
+        </Button>
+        <Button size="medium" variant="weak" color="primary" onClick={handleShare}>
+          결과 공유하기
+        </Button>
+      </div>
+
+      {shareMsg && <div className={styles.toast} aria-live="polite">{shareMsg}</div>}
       <Disclaimer />
     </div>
   )


### PR DESCRIPTION
## Summary

- ResultPage에 '결과 공유하기' 버튼 추가 (기존 '오늘 투표하기' 옆)
- `generateResultShareText()` 호출 — 군중 정답 여부 + 캐릭터 적중 + 내 예측 + 스트릭 포함
- 클립보드 복사 시 toast 알림 (`aria-live="polite"`)
- `.actions` CSS에 `gap: 8px` 추가 (두 버튼 배치)

## Test plan

- [x] 60 unit tests passing
- [x] TypeScript 0 errors
- [ ] ResultPage 접속 → '결과 공유하기' 버튼 표시 확인
- [ ] 클릭 → 공유 텍스트 클립보드 복사 + toast 확인
- [ ] 공유 텍스트에 군중 정답/오답, 캐릭터 결과, 스트릭 포함 확인

Closes #158

🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

- 투표 결과를 공유할 수 있는 공유 버튼이 추가되었습니다.
- 공유 기능을 통해 투표 정확도, 문자별 정답률, 연속 정답 정보를 포함한 상세한 결과를 복사할 수 있습니다.
- 결과 복사가 완료되면 화면 하단에 임시 알림 메시지가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->