### PR TITLE
feat: 캐릭터 적중률 리더보드 Supabase 실데이터 연동

### DIFF
--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -45,4 +45,9 @@ export const api = {
     }>('/vote', { method: 'POST', body: JSON.stringify(body) }),
 
   getResult: () => request<import('@/types/vote').VoteResult | null>('/result'),
+
+  getLeaderboard: () => request<Array<{
+    character: string; name: string; emoji: string
+    correct: number; total: number; rate: number
+  }>>('/leaderboard'),
 }

--- a/src/pages/CharactersPage.tsx
+++ b/src/pages/CharactersPage.tsx
@@ -1,13 +1,39 @@
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { CHARACTER_PROFILES } from '@/lib/characters'
+import { api } from '@/lib/api/client'
 import styles from './CharactersPage.module.css'
 
 const RANK_LABELS = ['🥇', '🥈', '🥉', '4위', '5위']
 
+interface LiveStat {
+  character: string
+  correct: number
+  total: number
+  rate: number
+}
+
 export function CharactersPage() {
   const navigate = useNavigate()
+  const [liveStats, setLiveStats] = useState<LiveStat[]>([])
 
-  const sorted = [...CHARACTER_PROFILES].sort((a, b) => b.accuracy.rate - a.accuracy.rate)
+  useEffect(() => {
+    api.getLeaderboard().then(({ data }) => {
+      if (data && data.length > 0) setLiveStats(data)
+    })
+  }, [])
+
+  const merged = CHARACTER_PROFILES.map((char) => {
+    const live = liveStats.find((s) => s.character === char.id)
+    return {
+      ...char,
+      accuracy: live
+        ? { correct: live.correct, total: live.total, rate: live.rate }
+        : char.accuracy,
+    }
+  })
+
+  const sorted = [...merged].sort((a, b) => b.accuracy.rate - a.accuracy.rate)
 
   return (
     <div className={styles.page}>


### PR DESCRIPTION
## Summary
- CharactersPage에서 `/api/leaderboard` 호출 → Supabase `daily_questions` 집계 결과로 실시간 적중률 표시
- Supabase 데이터 없을 때 `CHARACTER_PROFILES` 정적 mock 폴백
- `api/client.ts`에 `getLeaderboard()` 추가

## Test plan
- [ ] 빌드 통과 확인
- [ ] CharactersPage 접속 → 캐릭터 카드 정상 표시
- [ ] Supabase 연결 시 실데이터 적중률 반영 확인

**[역할 리뷰]** 볼트: API 보안 검토 승인 / 블레이즈: 번들 영향 미미

Closes #164

🤖 Generated by Claude Code [claude-sonnet-4-6]