### PR TITLE
feat: voteHistory 보관 기간 7 → 90일 확장 (#170)

### DIFF
--- a/src/lib/utils/__tests__/voteHistory.test.ts
+++ b/src/lib/utils/__tests__/voteHistory.test.ts
@@ -56,8 +56,8 @@ describe('getVote', () => {
     expect(getVote(mockRecord.questionId)).not.toBeNull()
   })
 
-  it('7일 이상 지난 기록은 null 반환', () => {
-    const oldDate = new Date(Date.now() - 8 * 86400000).toISOString().split('T')[0]
+  it('90일 이상 지난 기록은 null 반환', () => {
+    const oldDate = new Date(Date.now() - 91 * 86400000).toISOString().split('T')[0]
     localStorageMock.setItem(STORAGE_KEY, JSON.stringify([{ ...mockRecord, date: oldDate }]))
     expect(getVote(mockRecord.questionId)).toBeNull()
   })

--- a/src/lib/utils/voteHistory.ts
+++ b/src/lib/utils/voteHistory.ts
@@ -1,5 +1,5 @@
 const STORAGE_KEY = 'sp_vote_history'
-const MAX_AGE_DAYS = 7
+const MAX_AGE_DAYS = 90
 
 export type VoteRecord = {
   questionId: string


### PR DESCRIPTION
## Summary
- `MAX_AGE_DAYS` 7 → 90 — 스트릭/적중률 축적 시스템의 기반
- 7일 제한은 스트릭과 장기 적중률 데이터를 무의미하게 만듦
- 테스트 기준도 90일로 갱신

## Test plan
- [x] `pnpm test` 89개 통과
- [x] `pnpm build` 통과

🤖 Generated by Claude Code [claude-sonnet-4-6]