### PR TITLE
feat: 공유 카드 이미지 생성 — html-to-image (#171)

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@emotion/react": "^11.14.0",
     "@supabase/supabase-js": "^2.100.0",
     "@toss/tds-mobile": "^2.3.0",
+    "html-to-image": "^1.11.13",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^7.13.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       '@toss/tds-mobile':
         specifier: ^2.3.0
         version: 2.3.0(@emotion/react@11.14.0(@types/react@18.3.28)(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       react:
         specifier: ^18.2.0
         version: 18.2.0
@@ -1638,6 +1641,9 @@ packages:
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
     engines: {node: ^20.19.0 || ^22.12.0 || >=24.0.0}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -3945,6 +3951,8 @@ snapshots:
       '@exodus/bytes': 1.15.0
     transitivePeerDependencies:
       - '@noble/hashes'
+
+  html-to-image@1.11.13: {}
 
   https-proxy-agent@7.0.6:
     dependencies:

--- a/src/components/shared/ShareCard.tsx
+++ b/src/components/shared/ShareCard.tsx
@@ -1,0 +1,112 @@
+import type { VoteResult } from '@/types/vote'
+import type { VoteRecord } from '@/lib/utils/voteHistory'
+
+interface Props {
+  result: VoteResult
+  myVote: VoteRecord | null
+  streak: number
+  accuracyPercent: number | null
+}
+
+const OUTCOME_LABELS = { bullish: '올라갔다 📈', bearish: '망했다 📉', neutral: '그냥 그랬다 🤷' } as const
+
+export function ShareCard({ result, myVote, streak, accuracyPercent }: Props) {
+  const isCorrect = myVote?.choice === result.actualOutcome
+  const correctCount = result.characters.filter((c) => c.isCorrect).length
+
+  return (
+    <div style={{
+      width: 340,
+      background: '#ffffff',
+      borderRadius: 20,
+      padding: '24px 20px',
+      fontFamily: "'Toss Product Sans', -apple-system, sans-serif",
+      color: '#191f28',
+      boxShadow: '0 4px 24px rgba(0,0,0,0.12)',
+    }}>
+      {/* Header */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 6, marginBottom: 16 }}>
+        <span style={{ fontSize: 18, fontWeight: 800, color: '#3182f6' }}>시그널플레이</span>
+        <span style={{ fontSize: 12, color: '#8b95a1', marginLeft: 'auto' }}>오늘의 결과</span>
+      </div>
+
+      {/* Question */}
+      <p style={{ fontSize: 14, fontWeight: 600, lineHeight: 1.5, marginBottom: 12, color: '#191f28' }}>
+        {result.title}
+      </p>
+
+      {/* Outcome */}
+      <div style={{
+        background: '#f4f5f7',
+        borderRadius: 12,
+        padding: '10px 14px',
+        marginBottom: 12,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+      }}>
+        <span style={{ fontSize: 12, color: '#6b7684' }}>실제로는</span>
+        <span style={{ fontSize: 14, fontWeight: 700, color: '#191f28' }}>
+          {OUTCOME_LABELS[result.actualOutcome]}
+        </span>
+      </div>
+
+      {/* My result */}
+      {myVote && (
+        <div style={{
+          background: isCorrect ? '#e8f8ee' : '#fef0f0',
+          borderRadius: 12,
+          padding: '10px 14px',
+          marginBottom: 12,
+          display: 'flex',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        }}>
+          <span style={{ fontSize: 12, color: isCorrect ? '#1a7a40' : '#a83232' }}>내 예측</span>
+          <span style={{ fontSize: 14, fontWeight: 700, color: isCorrect ? '#1a7a40' : '#a83232' }}>
+            {isCorrect ? '✅ 적중!' : '❌ 빗나감'}
+          </span>
+        </div>
+      )}
+
+      {/* Character score */}
+      <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap', marginBottom: 12 }}>
+        {result.characters.map((c) => (
+          <div key={c.character} style={{
+            display: 'flex',
+            alignItems: 'center',
+            gap: 4,
+            background: c.isCorrect ? '#e8f8ee' : '#f4f5f7',
+            borderRadius: 8,
+            padding: '4px 8px',
+            fontSize: 12,
+          }}>
+            <span>{c.emoji}</span>
+            <span style={{ color: c.isCorrect ? '#1a7a40' : '#6b7684' }}>{c.isCorrect ? '✓' : '✗'}</span>
+          </div>
+        ))}
+        <span style={{ fontSize: 12, color: '#6b7684', alignSelf: 'center' }}>
+          {correctCount}/5 적중
+        </span>
+      </div>
+
+      {/* Stats */}
+      {(streak > 0 || accuracyPercent !== null) && (
+        <div style={{ display: 'flex', gap: 6 }}>
+          {streak > 0 && (
+            <span style={{
+              fontSize: 11, background: '#e8f0ff', color: '#3182f6',
+              borderRadius: 6, padding: '3px 8px', fontWeight: 600,
+            }}>🔥 {streak}일 연속</span>
+          )}
+          {accuracyPercent !== null && (
+            <span style={{
+              fontSize: 11, background: '#e8f8ee', color: '#1a7a40',
+              borderRadius: 6, padding: '3px 8px', fontWeight: 600,
+            }}>{accuracyPercent}% 적중률</span>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -1,5 +1,6 @@
-import { useState, useEffect, useCallback } from 'react'
+import { useState, useEffect, useCallback, useRef } from 'react'
 import { useNavigate } from 'react-router-dom'
+import { toPng } from 'html-to-image'
 import { showInterstitialAd } from '@/lib/bedrock'
 import { TdsButton as Button } from '@/components/shared/TdsButton'
 import { TdsBadge as Badge } from '@/components/shared/TdsBadge'
@@ -7,6 +8,7 @@ import { Disclaimer } from '@/components/shared/Disclaimer'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { CharacterCard } from '@/components/vote/CharacterCard'
 import { CrowdBar } from '@/components/vote/CrowdBar'
+import { ShareCard } from '@/components/shared/ShareCard'
 import { getVote } from '@/lib/utils/voteHistory'
 import { recordResult, getStreak, getAccuracyPercent } from '@/lib/utils/userStats'
 import { generateResultShareText, shareText } from '@/lib/utils/share'
@@ -28,6 +30,7 @@ export function ResultPage() {
   const navigate = useNavigate()
   const [result, setResult] = useState<VoteResult | null | undefined>(undefined)
   const [shareMsg, setShareMsg] = useState('')
+  const shareCardRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (!sessionStorage.getItem(AD_SESSION_KEY)) {
@@ -52,13 +55,29 @@ export function ResultPage() {
 
   const handleShare = useCallback(async () => {
     if (!result) return
+    const vote = getVote(result.questionId)
+
+    // 이미지 공유 시도
+    if (shareCardRef.current && navigator.canShare) {
+      try {
+        const dataUrl = await toPng(shareCardRef.current, { cacheBust: true, pixelRatio: 2 })
+        const res = await fetch(dataUrl)
+        const blob = await res.blob()
+        const file = new File([blob], 'signalplay-result.png', { type: 'image/png' })
+        if (navigator.canShare({ files: [file] })) {
+          await navigator.share({ files: [file], title: '시그널플레이 결과' })
+          return
+        }
+      } catch { /* 이미지 공유 실패 시 텍스트로 폴백 */ }
+    }
+
+    // 텍스트 폴백
     const crowdWon = result.crowdResult.bullish >= result.crowdResult.bearish &&
       result.crowdResult.bullish >= result.crowdResult.neutral
         ? result.actualOutcome === 'bullish'
         : result.crowdResult.bearish >= result.crowdResult.neutral
           ? result.actualOutcome === 'bearish'
           : result.actualOutcome === 'neutral'
-    const vote = getVote(result.questionId)
     const text = generateResultShareText({
       title: result.title,
       crowdCorrect: crowdWon,
@@ -226,6 +245,16 @@ export function ResultPage() {
 
       {shareMsg && <div className={styles.toast} aria-live="polite">{shareMsg}</div>}
       <Disclaimer />
+
+      {/* 공유 이미지 생성용 — 화면 밖에 렌더링 */}
+      <div ref={shareCardRef} style={{ position: 'fixed', left: '-9999px', top: 0, pointerEvents: 'none' }} aria-hidden="true">
+        <ShareCard
+          result={result}
+          myVote={myVote}
+          streak={getStreak()}
+          accuracyPercent={getAccuracyPercent()}
+        />
+      </div>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- `ShareCard` 컴포넌트 추가: 결과/내 예측/캐릭터 성적/스트릭을 시각적 카드로 렌더링
- `html-to-image` toPng로 이미지 생성 → `navigator.share({files: [PNG]})`로 네이티브 공유
- 폴백: 이미지 공유 미지원 환경에서 기존 텍스트 공유로 자동 전환
- ShareCard는 `position: fixed; left: -9999px`에 렌더링 → 화면 UX 무영향

## Bundle impact
| 청크 | 이전 | 이후 |
|------|------|------|
| ResultPage (lazy) | 6.56KB | 22.16KB |
| 초기 로드 (index) | 24.73KB | 24.73KB (무변화) |

ResultPage는 lazy-loaded이므로 초기 로드 성능 무영향.

## Test plan
- [x] `pnpm build` 통과
- [x] `pnpm test` 89개 통과
- [ ] 앱인토스 WebView에서 이미지 공유 동작 확인

🤖 Generated by Claude Code [claude-sonnet-4-6]