### PR TITLE
feat: 너의 투자 성향 — 누적 투표 기반 캐릭터 일치율 (#174)

### DIFF
--- a/.project/backlog.md
+++ b/.project/backlog.md
@@ -85,10 +85,12 @@
 
 ## P2 — 서비스 기획 v2 스프린트 (2026-03-26)
 
-- [ ] [FEATURE] @toss/tds-mobile 전면 도입 + Tossface CDN (PR #167 리뷰 중)
+- [x] [FEATURE] @toss/tds-mobile 전면 도입 + Tossface CDN (PR #167 merged)
 - [ ] [FEATURE] 공유 카드 이미지 생성 — html-to-image (PR #173 리뷰 중)
-- [ ] [FEATURE] voteHistory 보관 기간 7 → 90일 (PR #172 리뷰 중)
+- [x] [FEATURE] voteHistory 보관 기간 7 → 90일 (PR #172 merged)
+- [ ] [CONTENT] 운형 reasoning 강화 — Gemini 프롬프트에 일상 에피소드 지시 추가
 - [ ] [FEATURE] 너의 투자 성향 — 누적 투표 기반 캐릭터 일치율 (PR #175 리뷰 중)
+
 
 ## P2 — 레트로 도출 (다음 스프린트)
 

--- a/.project/quality-baseline.md
+++ b/.project/quality-baseline.md
@@ -15,7 +15,7 @@
 | JS 번들 (vendor, 캐시됨) | 40.72KB (14.50KB gzip) | 커지면 정당화 필요 | P2 |
 | JS 번들 (tds, 캐시됨) | 1,063KB (341KB gzip) — @toss/tds-mobile+@emotion, 앱인토스 심사 필수 | 고정값 (TDS 업데이트 시만 변경) | P2 |
 | CSS 번들 | 14.22KB (4.42KB gzip) | 커지면 정당화 필요 | P3 |
-| 테스트 커버리지 | 유닛 89개 (2026-03-26 갱신) | 올라가기만 함 | P1 |
+| 테스트 커버리지 | 유닛 92개 (2026-03-26 갱신) | 올라가기만 함 | P1 |
 | E2E 테스트 | 4개 (Playwright) — PR #127로 복구 | 올라가기만 함 | P1 |
 | 화면 깨짐 | 0건 | 항상 0 | P0 |
 | Lighthouse 성능 | 85점+ (TBT ≤300ms, 경고 0개) | 올라가기만 함 | P2 |
@@ -41,3 +41,4 @@
 | 2026-03-25 | P1 래칫 위반 복구 — E2E 3→4개 온보딩 spec 추가 (PR #127). | QA 호크 |
 | 2026-03-26 | JS 19.29→23.26KB (기능 다수 추가: profiles, share, preview, reactions, deadline 등 정당화). 유닛 78→89개 래칫 상향. | QA 호크 |
 | 2026-03-26 | @toss/tds-mobile 2.3.0 + @emotion/react 도입 (PR #166). tds 청크 1,063KB (캐시됨, 앱인토스 심사 정당화). vendor 180.5→40.72KB. Tossface CDN 추가. | QA 호크 |
+| 2026-03-26 | getCharacterAlignment() 유닛 3개 추가 (PR #174) — 유닛 89→92개 래칫 상향. | QA 호크 |

--- a/src/lib/utils/__tests__/userStats.test.ts
+++ b/src/lib/utils/__tests__/userStats.test.ts
@@ -4,6 +4,7 @@ import {
   recordResult,
   getStreak,
   getAccuracyPercent,
+  getCharacterAlignment,
 } from '../userStats'
 
 // localStorage mock
@@ -85,5 +86,50 @@ describe('recordResult / getAccuracyPercent', () => {
     recordResult('q-003', true)
     recordResult('q-004', true)
     expect(getAccuracyPercent()).toBe(75)
+  })
+})
+
+describe('getCharacterAlignment', () => {
+  const VOTE_KEY = 'sp_vote_history'
+
+  function makeRecord(questionId: string, choice: 'bullish' | 'bearish', quantPred: string) {
+    return {
+      questionId,
+      date: '2026-03-20',
+      title: '테스트 질문',
+      choice,
+      characterPredictions: [
+        { character: 'quant', prediction: quantPred },
+        { character: 'chimp', prediction: 'neutral' },
+      ],
+    }
+  }
+
+  it('투표 3회 미만이면 null 반환', () => {
+    store[VOTE_KEY] = JSON.stringify([
+      makeRecord('q-1', 'bullish', 'bullish'),
+      makeRecord('q-2', 'bullish', 'bullish'),
+    ])
+    expect(getCharacterAlignment()).toBeNull()
+  })
+
+  it('quant 3회 일치 → quant 반환', () => {
+    store[VOTE_KEY] = JSON.stringify([
+      makeRecord('q-1', 'bullish', 'bullish'),
+      makeRecord('q-2', 'bullish', 'bullish'),
+      makeRecord('q-3', 'bullish', 'bullish'),
+    ])
+    const result = getCharacterAlignment()
+    expect(result?.character).toBe('quant')
+    expect(result?.rate).toBe(100)
+  })
+
+  it('characterPredictions 없는 기록은 집계에서 제외', () => {
+    store[VOTE_KEY] = JSON.stringify([
+      { questionId: 'q-1', date: '2026-03-20', title: '테스트', choice: 'bullish' },
+      { questionId: 'q-2', date: '2026-03-20', title: '테스트', choice: 'bullish' },
+      { questionId: 'q-3', date: '2026-03-20', title: '테스트', choice: 'bullish' },
+    ])
+    expect(getCharacterAlignment()).toBeNull()
   })
 })

--- a/src/lib/utils/userStats.ts
+++ b/src/lib/utils/userStats.ts
@@ -1,3 +1,5 @@
+import { getHistory } from './voteHistory'
+
 const STATS_KEY = 'sp_user_stats'
 
 interface UserStats {
@@ -68,4 +70,38 @@ export function getAccuracyPercent(): number | null {
   const { correct, total } = getStats()
   if (total === 0) return null
   return Math.round((correct / total) * 100)
+}
+
+const CHARACTER_NAMES: Record<string, { name: string; emoji: string }> = {
+  quant:     { name: '밸류김', emoji: '💼' },
+  professor: { name: '팩터박', emoji: '📚' },
+  reporter:  { name: '뉴스최', emoji: '📺' },
+  pattern:   { name: '봉준선', emoji: '📐' },
+  chimp:     { name: '코인토', emoji: '🎲' },
+}
+
+/** 누적 투표 기반 가장 일치하는 캐릭터 — 3회 미만 투표 시 null */
+export function getCharacterAlignment(): { character: string; name: string; emoji: string; rate: number } | null {
+  const history = getHistory().filter((r) => r.characterPredictions && r.characterPredictions.length > 0)
+  if (history.length < 3) return null
+
+  const counts: Record<string, { match: number; total: number }> = {}
+  for (const record of history) {
+    for (const cp of record.characterPredictions!) {
+      if (!counts[cp.character]) counts[cp.character] = { match: 0, total: 0 }
+      counts[cp.character].total++
+      if (cp.prediction === record.choice) counts[cp.character].match++
+    }
+  }
+
+  let best: { character: string; rate: number } | null = null
+  for (const [char, { match, total }] of Object.entries(counts)) {
+    if (total < 3) continue
+    const rate = Math.round((match / total) * 100)
+    if (!best || rate > best.rate) best = { character: char, rate }
+  }
+
+  if (!best) return null
+  const meta = CHARACTER_NAMES[best.character]
+  return meta ? { character: best.character, name: meta.name, emoji: meta.emoji, rate: best.rate } : null
 }

--- a/src/lib/utils/voteHistory.ts
+++ b/src/lib/utils/voteHistory.ts
@@ -6,9 +6,10 @@ export type VoteRecord = {
   date: string
   title: string
   choice: 'bullish' | 'bearish' | 'neutral'
+  characterPredictions?: Array<{ character: string; prediction: string }>
 }
 
-function getHistory(): VoteRecord[] {
+export function getHistory(): VoteRecord[] {
   try {
     const raw = localStorage.getItem(STORAGE_KEY)
     if (!raw) return []

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -8,7 +8,7 @@ import { EmptyState } from '@/components/shared/EmptyState'
 import { CharacterCard } from '@/components/vote/CharacterCard'
 import { CrowdBar } from '@/components/vote/CrowdBar'
 import { getVote } from '@/lib/utils/voteHistory'
-import { recordResult, getStreak, getAccuracyPercent } from '@/lib/utils/userStats'
+import { recordResult, getStreak, getAccuracyPercent, getCharacterAlignment } from '@/lib/utils/userStats'
 import { generateResultShareText, shareText } from '@/lib/utils/share'
 import { MOCK_VOTE_RESULT, MOCK_CHARACTER_ACCURACY } from '@/lib/mockData'
 import { api } from '@/lib/api/client'
@@ -138,16 +138,27 @@ export function ResultPage() {
       </div>
 
       {/* 내 성적 배지 */}
-      {(getStreak() > 0 || getAccuracyPercent() !== null) && (
-        <div className={styles.statsRow}>
-          {getStreak() > 0 && (
-            <Badge size="small" variant="weak" color="blue">🔥 {getStreak()}일 연속</Badge>
-          )}
-          {getAccuracyPercent() !== null && (
-            <Badge size="small" variant="weak" color="green">{getAccuracyPercent()}% 적중</Badge>
-          )}
-        </div>
-      )}
+      {(() => {
+        const streak = getStreak()
+        const accuracy = getAccuracyPercent()
+        const alignment = getCharacterAlignment()
+        if (streak === 0 && accuracy === null && alignment === null) return null
+        return (
+          <div className={styles.statsRow}>
+            {streak > 0 && (
+              <Badge size="small" variant="weak" color="blue">🔥 {streak}일 연속</Badge>
+            )}
+            {accuracy !== null && (
+              <Badge size="small" variant="weak" color="green">{accuracy}% 적중</Badge>
+            )}
+            {alignment !== null && (
+              <Badge size="small" variant="weak" color="elephant">
+                {alignment.emoji} {alignment.name}파 {alignment.rate}%
+              </Badge>
+            )}
+          </div>
+        )
+      })()}
 
       {/* Crowd result */}
       <div className={styles.section}>

--- a/src/pages/VotePage.tsx
+++ b/src/pages/VotePage.tsx
@@ -69,7 +69,13 @@ export function VotePage() {
     if (voted || !questionData) return
     setVoted(choice)
     setShowSuccess(true)
-    saveVote({ questionId: questionData.id, date: questionData.date, title: questionData.title, choice })
+    saveVote({
+      questionId: questionData.id,
+      date: questionData.date,
+      title: questionData.title,
+      choice,
+      characterPredictions: questionData.characters.map((c) => ({ character: c.character, prediction: c.prediction })),
+    })
     recordVote(questionData.date)
     const { data } = await api.vote({ questionId: questionData.id, vote: choice })
     if (data?.crowd) {


### PR DESCRIPTION
## Summary
- `VoteRecord`에 `characterPredictions` 추가 (optional, 기존 데이터 하위 호환)
- 투표 시 캐릭터 예측도 함께 localStorage에 저장
- `getCharacterAlignment()`: 3회+ 투표 기록에서 가장 일치율 높은 캐릭터 계산
- ResultPage 성적 배지 행에 투자 성향 표시: `📚 팩터박파 70%`
- `voteHistory`: MAX_AGE_DAYS 7→90, `getHistory` export

## Example output
> 🔥 5일 연속 &nbsp;|&nbsp; 68% 적중 &nbsp;|&nbsp; 📚 팩터박파 72%

## Tests
- `getCharacterAlignment()` 유닛 3개 추가 → 89→92개 래칫 상향

## Test plan
- [x] `pnpm build` 통과
- [x] `pnpm test` 92개 통과

🤖 Generated by Claude Code [claude-sonnet-4-6]