### PR TITLE
fix: api/question Supabase 캐시 우선 조회 (#178)

### DIFF
--- a/api/question.ts
+++ b/api/question.ts
@@ -108,6 +108,36 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const today = new Date().toISOString().split('T')[0]
   if (cache?.date === today) return res.status(200).json(cache.data)
 
+  // 0. Supabase 캐시 확인 — 오늘 데이터가 이미 있으면 즉시 반환
+  const supabase = getSupabase()
+  if (supabase) {
+    const { data: existing } = await supabase
+      .from('daily_questions')
+      .select('*')
+      .eq('date', today)
+      .single()
+    if (existing) {
+      const { data: voteData } = await supabase
+        .from('user_votes')
+        .select('prediction')
+        .eq('question_id', existing.id)
+      const totalVotes = voteData?.length ?? 0
+      const cached = {
+        id: existing.id,
+        date: existing.date,
+        title: existing.title,
+        question: existing.question,
+        category: existing.category,
+        characters: existing.character_predictions ?? [],
+        totalVotes,
+        deadline: existing.deadline,
+        isActive: new Date() < new Date(existing.deadline),
+      }
+      cache = { date: today, data: cached }
+      return res.status(200).json(cached)
+    }
+  }
+
   // 1. Generate question (Google Search Grounding으로 실시간 뉴스 기반)
   const qRaw = await callGemini(buildQuestionPrompt(today), true)
   let question = qRaw ? parseJson(qRaw) as { title: string; question: string; category: string } | null : null
@@ -162,7 +192,6 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   cache = { date: today, data: response }
 
   // Supabase upsert — 환경변수 설정 시 활성화
-  const supabase = getSupabase()
   if (supabase) {
     await supabase.from('daily_questions').upsert({
       id: response.id,


### PR DESCRIPTION
## Summary
- `api/question.ts` 핸들러 최상단에 Supabase read-first 로직 추가
- 오늘 날짜 row가 있으면 `user_votes` totalVotes 합산 후 즉시 반환
- 없을 때만 Gemini 호출 → Supabase upsert (기존 동작 유지)
- 하단의 중복 `getSupabase()` 호출 제거 (상단에서 선언한 변수 재사용)

## Test plan
- [ ] 로컬: Supabase에 오늘 날짜 row 있을 때 → Gemini 호출 없이 DB 데이터 반환 확인
- [ ] 로컬: Supabase에 오늘 날짜 row 없을 때 → Gemini 호출 후 upsert 정상 동작
- [ ] TypeScript 에러 0개 (`tsc --noEmit`)

Closes #178

🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 일일 문제 조회 시 캐싱 시스템을 통한 성능 개선
* 각 일일 문제에 마감 시간 및 활성 상태 정보 추가
* 사용자 투표 기반 캐릭터 예측 결과 통합

<!-- end of auto-generated comment: release notes by coderabbit.ai -->