### PR TITLE
feat: 캐릭터 장 중 드라마 — 낮 코멘트 + 결과 반응 + 투표 후 타임라인 (#186)

### DIFF
--- a/.project/backlog.md
+++ b/.project/backlog.md
@@ -12,7 +12,7 @@
 - [x] [BUG] E2E 테스트 피벗 반영 (#38 merged)
 - [x] [PROCESS] 구 코드 정리 (BattlePage/FeedPage/RankingPage 삭제)
 - [x] [FEATURE] Gemini 실시간 질문 생성 — Google Search Grounding (#42 merged)
-- [ ] [PROCESS] Supabase 프로젝트 생성 + 스키마 적용 (CEO 액션) — PR #71 준비 완료, supabase login 후 적용 가능
+- [x] [PROCESS] Supabase 프로젝트 생성 + 스키마 적용 — 3테이블 RLS 정상, Vercel env 연결 완료
 - [x] [FEATURE] 알고리즘 고도화 1단계 — 캐릭터별 독립 프롬프트 + reasoning 필드 (ADR-009, b807b1b + CharacterCard #58)
 
 ---

--- a/api/cron/midday.ts
+++ b/api/cron/midday.ts
@@ -1,0 +1,148 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { getSupabase } from '../_supabase'
+
+/**
+ * Cron: 매일 03:00 UTC (12:00 KST) 장 중 캐릭터 코멘트 생성
+ * vercel.json: "schedule": "0 3 * * *"
+ *
+ * 흐름:
+ * 1. 오늘 질문 조회 (midday_comments가 아직 없는 것)
+ * 2. Gemini로 캐릭터별 "지금 이 시점에 한마디" 생성
+ * 3. daily_questions.midday_comments 업데이트
+ */
+
+const GEMINI_API_KEY = process.env.GEMINI_API_KEY
+const GEMINI_URL =
+  'https://generativelanguage.googleapis.com/v1beta/models/gemini-2.5-flash:generateContent'
+
+interface CharacterPrediction {
+  character: string
+  name: string
+  emoji: string
+  prediction: 'bullish' | 'bearish' | 'neutral'
+  reasoning: string
+}
+
+interface MiddayComment {
+  character: string
+  name: string
+  emoji: string
+  comment: string
+}
+
+async function generateMiddayComments(
+  title: string,
+  question: string,
+  characters: CharacterPrediction[],
+): Promise<MiddayComment[] | null> {
+  if (!GEMINI_API_KEY) return null
+
+  const characterList = characters
+    .map((c) => `- ${c.emoji} ${c.name}(${c.character}): ${c.prediction === 'bullish' ? '호재' : c.prediction === 'bearish' ? '악재' : '글쎄'} 예측 — "${c.reasoning.slice(0, 80)}"`)
+    .join('\n')
+
+  const prompt = `당신은 방구석 투자 전문가 5명입니다. 오늘 오전에 아래 이슈를 예측했고, 지금은 낮 12시입니다.
+장이 열린지 3시간이 지났고, 오후 3시 30분에 결과가 나옵니다.
+
+이슈: "${title}" — ${question}
+
+오전 예측:
+${characterList}
+
+각 캐릭터가 지금 이 시점에 한마디씩 합니다. 각자의 성격대로, 20자 이내로.
+아직 결과는 모릅니다. 긴장감, 자신감, 불안함 등이 섞여있어야 합니다.
+
+밸류김(quant): 숫자 중심, 단호
+팩터박(professor): 학문적, 잘난 척
+뉴스최(reporter): 속보 중독, 소식통
+봉준선(pattern): 신비주의, 차트 집착
+코인토(chimp): 순수, 감으로 찍기
+
+JSON 배열로만 응답:
+[
+  {"character":"quant","name":"밸류김","emoji":"💼","comment":"한마디"},
+  {"character":"professor","name":"팩터박","emoji":"📚","comment":"한마디"},
+  {"character":"reporter","name":"뉴스최","emoji":"📺","comment":"한마디"},
+  {"character":"pattern","name":"봉준선","emoji":"📐","comment":"한마디"},
+  {"character":"chimp","name":"코인토","emoji":"🎲","comment":"한마디"}
+]`
+
+  try {
+    const body = {
+      contents: [{ parts: [{ text: prompt }] }],
+      generationConfig: { temperature: 0.8, maxOutputTokens: 512 },
+    }
+
+    const res = await fetch(`${GEMINI_URL}?key=${GEMINI_API_KEY}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(20000),
+    })
+
+    if (!res.ok) return null
+
+    const data = await res.json()
+    const raw: string = data.candidates?.[0]?.content?.parts?.[0]?.text ?? ''
+    const match = raw.match(/\[[\s\S]*\]/)
+    if (!match) return null
+
+    const parsed = JSON.parse(match[0]) as MiddayComment[]
+    if (!Array.isArray(parsed) || parsed.length === 0) return null
+
+    return parsed
+  } catch {
+    return null
+  }
+}
+
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  const cronSecret = process.env.CRON_SECRET
+  const authHeader = req.headers['authorization']
+  if (cronSecret && authHeader !== `Bearer ${cronSecret}`) {
+    return res.status(401).json({ error: 'Unauthorized' })
+  }
+
+  const supabase = getSupabase()
+  if (!supabase) {
+    return res.status(200).json({ ok: true, skipped: true, reason: 'Supabase not configured' })
+  }
+
+  // 오늘 날짜
+  const today = new Date().toISOString().slice(0, 10)
+
+  const { data: question, error } = await supabase
+    .from('daily_questions')
+    .select('id, title, question, character_predictions')
+    .eq('date', today)
+    .eq('result_ready', false)
+    .is('midday_comments', null)
+    .maybeSingle()
+
+  if (error) return res.status(500).json({ error: error.message })
+  if (!question) return res.status(200).json({ ok: true, skipped: true, reason: 'No pending question' })
+
+  const characters = (question.character_predictions ?? []) as CharacterPrediction[]
+  if (characters.length === 0) {
+    return res.status(200).json({ ok: true, skipped: true, reason: 'No character predictions' })
+  }
+
+  const comments = await generateMiddayComments(
+    question.title as string,
+    question.question as string,
+    characters,
+  )
+
+  if (!comments) {
+    return res.status(200).json({ ok: true, skipped: true, reason: 'Gemini generation failed' })
+  }
+
+  const { error: updateErr } = await supabase
+    .from('daily_questions')
+    .update({ midday_comments: comments })
+    .eq('id', question.id)
+
+  if (updateErr) return res.status(500).json({ error: updateErr.message })
+
+  return res.status(200).json({ ok: true, questionId: question.id, generated: comments.length })
+}

--- a/api/cron/set-result.ts
+++ b/api/cron/set-result.ts
@@ -10,6 +10,7 @@ import { getSupabase } from '../_supabase'
  * 2. Gemini Search로 종목/이슈 당일 주가 변동률 조회
  * 3. +1% 이상 → bullish, -1% 이하 → bearish, 그 사이 → neutral
  * 4. daily_questions 업데이트 + user_votes is_correct 일괄 업데이트
+ * 5. 캐릭터 승패 반응 대사 생성 → close_reactions 저장
  */
 
 const GEMINI_API_KEY = process.env.GEMINI_API_KEY
@@ -73,6 +74,73 @@ JSON으로만 응답:
   }
 }
 
+interface CharacterPrediction {
+  character: string
+  name: string
+  emoji: string
+  prediction: 'bullish' | 'bearish' | 'neutral'
+}
+
+async function generateCloseReactions(
+  title: string,
+  outcome: 'bullish' | 'bearish' | 'neutral',
+  characters: CharacterPrediction[],
+): Promise<object[] | null> {
+  if (!GEMINI_API_KEY) return null
+
+  const outcomeLabel = outcome === 'bullish' ? '호재(상승)' : outcome === 'bearish' ? '악재(하락)' : '중립(횡보)'
+  const characterList = characters
+    .map((c) => {
+      const pred = c.prediction === 'bullish' ? '호재' : c.prediction === 'bearish' ? '악재' : '글쎄'
+      const hit = c.prediction === outcome
+      return `- ${c.emoji} ${c.name}(${c.character}): ${pred} 예측 → ${hit ? '✅ 적중' : '❌ 빗나감'}`
+    })
+    .join('\n')
+
+  const prompt = `방구석 투자 전문가 5명이 오늘 예측을 했고, 장이 마감되었습니다.
+
+이슈: "${title}"
+실제 결과: ${outcomeLabel}
+
+각 캐릭터의 예측 결과:
+${characterList}
+
+각 캐릭터가 결과를 보고 한마디씩 합니다. 각자의 성격대로. 20자 이내.
+- 적중한 캐릭터: 자랑, 확신, 뿌듯함
+- 틀린 캐릭터: 변명, 합리화, 다음엔 맞출 거라는 의지
+
+JSON 배열로만 응답:
+[
+  {"character":"quant","name":"밸류김","emoji":"💼","comment":"한마디","isCorrect":true/false},
+  {"character":"professor","name":"팩터박","emoji":"📚","comment":"한마디","isCorrect":true/false},
+  {"character":"reporter","name":"뉴스최","emoji":"📺","comment":"한마디","isCorrect":true/false},
+  {"character":"pattern","name":"봉준선","emoji":"📐","comment":"한마디","isCorrect":true/false},
+  {"character":"chimp","name":"코인토","emoji":"🎲","comment":"한마디","isCorrect":true/false}
+]`
+
+  try {
+    const body = {
+      contents: [{ parts: [{ text: prompt }] }],
+      generationConfig: { temperature: 0.9, maxOutputTokens: 512 },
+    }
+    const res = await fetch(`${GEMINI_URL}?key=${GEMINI_API_KEY}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(20000),
+    })
+    if (!res.ok) return null
+    const data = await res.json()
+    const raw: string = data.candidates?.[0]?.content?.parts?.[0]?.text ?? ''
+    const match = raw.match(/\[[\s\S]*\]/)
+    if (!match) return null
+    const parsed = JSON.parse(match[0]) as object[]
+    return Array.isArray(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   // Cron 보안 검증
   const cronSecret = process.env.CRON_SECRET
@@ -91,7 +159,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const now = new Date().toISOString()
   const { data: questions, error } = await supabase
     .from('daily_questions')
-    .select('id, date, title')
+    .select('id, date, title, character_predictions')
     .eq('result_ready', false)
     .lt('deadline', now)
     .order('date', { ascending: false })
@@ -136,6 +204,18 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       .update({ is_correct: true })
       .eq('question_id', q.id)
       .eq('choice', outcome)
+
+    // 3. 캐릭터 승패 반응 생성
+    const characters = (q.character_predictions ?? []) as CharacterPrediction[]
+    if (characters.length > 0) {
+      const reactions = await generateCloseReactions(q.title as string, outcome, characters)
+      if (reactions) {
+        await supabase
+          .from('daily_questions')
+          .update({ close_reactions: reactions })
+          .eq('id', q.id)
+      }
+    }
 
     results.push({ questionId: q.id as string, outcome, changePercent })
   }

--- a/api/updates.ts
+++ b/api/updates.ts
@@ -1,0 +1,34 @@
+import type { VercelRequest, VercelResponse } from '@vercel/node'
+import { getSupabase } from './_supabase'
+
+/**
+ * GET /api/updates?questionId=...
+ * 오늘 질문의 캐릭터 장 중 업데이트 반환
+ * - midday_comments: 낮 12시 코멘트 (nullable)
+ * - close_reactions: 장 마감 후 승패 반응 (nullable)
+ */
+export default async function handler(req: VercelRequest, res: VercelResponse) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' })
+
+  const supabase = getSupabase()
+  if (!supabase) return res.status(200).json({ midday_comments: null, close_reactions: null })
+
+  const { questionId } = req.query
+  if (!questionId || typeof questionId !== 'string') {
+    return res.status(400).json({ error: 'questionId required' })
+  }
+
+  const { data, error } = await supabase
+    .from('daily_questions')
+    .select('midday_comments, close_reactions')
+    .eq('id', questionId)
+    .maybeSingle()
+
+  if (error) return res.status(500).json({ error: error.message })
+  if (!data) return res.status(200).json({ midday_comments: null, close_reactions: null })
+
+  return res.status(200).json({
+    midday_comments: data.midday_comments ?? null,
+    close_reactions: data.close_reactions ?? null,
+  })
+}

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -50,4 +50,9 @@ export const api = {
     character: string; name: string; emoji: string
     correct: number; total: number; rate: number
   }>>('/leaderboard'),
+
+  getUpdates: (questionId: string) => request<{
+    midday_comments: Array<{ character: string; name: string; emoji: string; comment: string }> | null
+    close_reactions: Array<{ character: string; name: string; emoji: string; comment: string; isCorrect: boolean }> | null
+  }>(`/updates?questionId=${questionId}`),
 }

--- a/src/pages/VotePage.module.css
+++ b/src/pages/VotePage.module.css
@@ -133,3 +133,63 @@
   flex-direction: column;
   gap: 8px;
 }
+
+/* 캐릭터 드라마 타임라인 */
+.dramaSection {
+  margin-top: 16px;
+  background: #f8f9fa;
+  border-radius: 12px;
+  padding: 12px 14px;
+}
+
+.dramaLabel {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+  margin-bottom: 10px;
+}
+
+.dramaList {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.dramaItem {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+}
+
+.dramaEmoji {
+  font-size: 22px;
+  flex-shrink: 0;
+  line-height: 1.2;
+}
+
+.dramaName {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--color-text-secondary);
+}
+
+.dramaResult {
+  font-size: 12px;
+}
+
+.dramaComment {
+  font-size: 13px;
+  color: var(--color-text);
+  margin-top: 2px;
+  line-height: 1.4;
+}
+
+.resultWait {
+  margin-top: 14px;
+  font-size: 13px;
+  color: var(--color-text-secondary);
+  text-align: center;
+  padding: 10px;
+  background: #f8f9fa;
+  border-radius: 8px;
+}

--- a/src/pages/VotePage.tsx
+++ b/src/pages/VotePage.tsx
@@ -53,6 +53,10 @@ export function VotePage() {
   const [voted, setVoted] = useState<VoteChoice | null>(null)
   const [showSuccess, setShowSuccess] = useState(false)
   const [hasResult, setHasResult] = useState(false)
+  const [updates, setUpdates] = useState<{
+    midday_comments: Array<{ character: string; name: string; emoji: string; comment: string }> | null
+    close_reactions: Array<{ character: string; name: string; emoji: string; comment: string; isCorrect: boolean }> | null
+  } | null>(null)
   const { openToast } = useWebToast()
   const { openOneButtonSheet } = useBottomSheet()
 
@@ -61,7 +65,10 @@ export function VotePage() {
       const q = data ?? ({ ...MOCK_TODAY_QUESTION, characters: MOCK_CHARACTER_PREDICTIONS } as QuestionData)
       setQuestionData(q)
       const existing = getVote(q.id)
-      if (existing) setVoted(existing.choice)
+      if (existing) {
+        setVoted(existing.choice)
+        api.getUpdates(q.id).then(({ data: upd }) => { if (upd) setUpdates(upd) })
+      }
       setLoading(false)
     })
     api.getResult().then(({ data }) => {
@@ -85,6 +92,7 @@ export function VotePage() {
     if (data?.crowd) {
       setCrowd({ ...data.crowd })
     }
+    api.getUpdates(questionData.id).then(({ data: upd }) => { if (upd) setUpdates(upd) })
     // 첫 투표 후 앱 설명 바텀시트 (1회만)
     if (!localStorage.getItem(FIRST_VOTE_KEY)) {
       localStorage.setItem(FIRST_VOTE_KEY, 'true')
@@ -211,6 +219,45 @@ export function VotePage() {
             return <p className={styles.syncMsg}>{msg}</p>
           })()}
           <CrowdBar result={crowd} animated />
+
+          {/* 캐릭터 드라마 타임라인 */}
+          {updates?.midday_comments && (
+            <div className={styles.dramaSection}>
+              <p className={styles.dramaLabel}>☀️ 낮 12시 — 전문가들 근황</p>
+              <div className={styles.dramaList}>
+                {updates.midday_comments.map((c) => (
+                  <div key={c.character} className={styles.dramaItem}>
+                    <span className={styles.dramaEmoji}>{c.emoji}</span>
+                    <div>
+                      <span className={styles.dramaName}>{c.name}</span>
+                      <p className={styles.dramaComment}>"{c.comment}"</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {updates?.close_reactions ? (
+            <div className={styles.dramaSection}>
+              <p className={styles.dramaLabel}>🏁 결과 반응</p>
+              <div className={styles.dramaList}>
+                {updates.close_reactions.map((c) => (
+                  <div key={c.character} className={styles.dramaItem}>
+                    <span className={styles.dramaEmoji}>{c.emoji}</span>
+                    <div>
+                      <span className={styles.dramaName}>{c.name}</span>
+                      <span className={styles.dramaResult}>{c.isCorrect ? ' ✅' : ' ❌'}</span>
+                      <p className={styles.dramaComment}>"{c.comment}"</p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          ) : (
+            <p className={styles.resultWait}>🔔 오후 3:30 장 마감 후 결과 공개</p>
+          )}
+
           <Button size="medium" variant="weak" color="primary" onClick={handleShare} className={styles.shareBtn}>
             친구한테 물어봐 💬
           </Button>

--- a/vercel.json
+++ b/vercel.json
@@ -23,8 +23,12 @@
       "schedule": "50 23 * * *"
     },
     {
+      "path": "/api/cron/midday",
+      "schedule": "0 3 * * 1-5"
+    },
+    {
       "path": "/api/cron/set-result",
-      "schedule": "0 7 * * *"
+      "schedule": "0 7 * * 1-5"
     }
   ]
 }


### PR DESCRIPTION
## Summary
투표 후 볼 게 없다는 서비스 본질 문제 해결. 캐릭터가 하루 종일 살아있는 존재처럼 동작.

- **DB**: `midday_comments`, `close_reactions` jsonb 컬럼 추가
- **Cron** `api/cron/midday.ts`: 매일 12:00 KST(평일) 캐릭터별 장 중 한마디 Gemini 생성
- **Cron** `set-result.ts`: 결과 판정 후 캐릭터 승패 반응 대사 생성 → `close_reactions` 저장
- **API** `api/updates.ts`: `GET /api/updates?questionId=` — 프론트 폴링용
- **VotePage**: 투표 후 드라마 타임라인 — 낮 코멘트 / 결과 반응 / 대기 상태 표시

## 하루 흐름
```
오전 9시   질문 + 투표 → 군중 비율 공개
낮 12시    캐릭터 장 중 한마디 (cron) → 타임라인에 추가
오후 3:30  장 마감 → actual_outcome 판정 + 캐릭터 승패 반응 생성
```

## Test plan
- [ ] 투표 후 "🔔 오후 3:30 결과 공개" 대기 메시지 표시
- [ ] midday_comments 있을 때 "☀️ 낮 12시 전문가 근황" 섹션 표시
- [ ] close_reactions 있을 때 "🏁 결과 반응" 섹션 표시
- [ ] `pnpm build` ✅ `pnpm lint` ✅

Closes #186

🤖 Generated by Claude Code [claude-sonnet-4-6]