### PR TITLE
feat: ResultPage 캐릭터 결과 반응 대사 — close_reactions DB 연동 (#188)

### DIFF
--- a/api/result.ts
+++ b/api/result.ts
@@ -24,11 +24,17 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const crowdBearish = Math.round(((data.crowd_bearish ?? 0) / total) * 100)
   const crowdNeutral = 100 - crowdBullish - crowdBearish
 
-  // 캐릭터별 isCorrect 계산
+  // close_reactions 매핑 (캐릭터별 반응 코멘트)
+  const reactionsMap: Record<string, string> = {}
+  const closeReactions = (data.close_reactions ?? []) as Array<{ character: string; comment: string }>
+  for (const r of closeReactions) reactionsMap[r.character] = r.comment
+
+  // 캐릭터별 isCorrect + reaction 병합
   const characters = (data.character_predictions ?? []).map(
     (c: { character: string; name: string; emoji: string; methodology: string; prediction: string; reasoning: string }) => ({
       ...c,
       isCorrect: c.prediction === data.actual_outcome,
+      ...(reactionsMap[c.character] ? { reaction: reactionsMap[c.character] } : {}),
     })
   )
 

--- a/src/components/vote/CharacterCard.tsx
+++ b/src/components/vote/CharacterCard.tsx
@@ -114,9 +114,9 @@ export function CharacterCard({ prediction, isCorrect, showCorrect = false, defa
 
           {unlocked && showCorrect && isCorrect !== undefined && (
             <p className={`${styles.reaction} ${isCorrect ? styles.reactionCorrect : styles.reactionWrong}`}>
-              {isCorrect
+              {prediction.reaction ?? (isCorrect
                 ? CHARACTER_REACTIONS[prediction.character].correct
-                : CHARACTER_REACTIONS[prediction.character].wrong}
+                : CHARACTER_REACTIONS[prediction.character].wrong)}
             </p>
           )}
         </div>

--- a/src/types/vote.ts
+++ b/src/types/vote.ts
@@ -18,6 +18,7 @@ export interface CharacterPrediction {
   prediction: VoteChoice
   reasoning: string
   methodology: string
+  reaction?: string
 }
 
 export interface CrowdResult {


### PR DESCRIPTION
## Summary
결과 페이지가 드라마 클라이맥스인데 캐릭터 반응이 없던 문제 해결.
Gemini가 생성한 맥락적 반응 대사를 하드코딩 fallback보다 우선 표시.

- `types/vote.ts`: `CharacterPrediction.reaction?` 옵셔널 필드 추가
- `api/result.ts`: `close_reactions` jsonb를 characters 배열에 병합
- `CharacterCard`: `prediction.reaction` 있으면 우선, 없으면 기존 하드코딩 fallback

## Test plan
- [ ] 결과 있는 질문에서 CharacterCard 펼쳤을 때 반응 대사 표시
- [ ] `pnpm build` ✅ / 92 tests ✅

Closes #188

🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* 캐릭터별 반응 정보가 시스템에 추가되었습니다.
* 캐릭터 카드에서 각 캐릭터의 반응 메시지를 표시합니다.
* 반응 표시 로직이 개선되어 더욱 정확한 피드백을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->