### PR TITLE
fix: 재방문 투표자 군중 비율 Mock 표시 버그 수정 (#190)

### DIFF
--- a/api/question.ts
+++ b/api/question.ts
@@ -122,6 +122,10 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         .select('prediction')
         .eq('question_id', existing.id)
       const totalVotes = voteData?.length ?? 0
+      const total = existing.total_votes || totalVotes || 1
+      const crowdBullish = Math.round(((existing.crowd_bullish ?? 0) / total) * 100)
+      const crowdBearish = Math.round(((existing.crowd_bearish ?? 0) / total) * 100)
+      const crowdNeutral = 100 - crowdBullish - crowdBearish
       const cached = {
         id: existing.id,
         date: existing.date,
@@ -129,7 +133,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         question: existing.question,
         category: existing.category,
         characters: existing.character_predictions ?? [],
-        totalVotes,
+        totalVotes: existing.total_votes ?? totalVotes,
+        crowd: { bullish: crowdBullish, bearish: crowdBearish, neutral: crowdNeutral, totalVotes: existing.total_votes ?? totalVotes },
         deadline: existing.deadline,
         isActive: new Date() < new Date(existing.deadline),
       }

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -36,6 +36,7 @@ export const api = {
     totalVotes: number
     deadline: string
     isActive: boolean
+    crowd?: import('@/types/vote').CrowdResult
   }>('/question'),
 
   vote: (body: { questionId: string; vote: string; userId?: string }) =>

--- a/src/pages/VotePage.tsx
+++ b/src/pages/VotePage.tsx
@@ -43,7 +43,7 @@ const CATEGORY_COLOR: Record<string, 'blue' | 'green' | 'yellow'> = {
   매크로: 'yellow',
 }
 
-type QuestionData = Question & { characters: CharacterPrediction[] }
+type QuestionData = Question & { characters: CharacterPrediction[]; crowd?: CrowdResult }
 
 export function VotePage() {
   const navigate = useNavigate()
@@ -67,6 +67,7 @@ export function VotePage() {
       const existing = getVote(q.id)
       if (existing) {
         setVoted(existing.choice)
+        if (q.crowd) setCrowd(q.crowd)
         api.getUpdates(q.id).then(({ data: upd }) => { if (upd) setUpdates(upd) })
       }
       setLoading(false)


### PR DESCRIPTION
## 버그
이미 투표한 사용자가 재진입 시 군중 비율이 33/33/33% Mock으로 표시됨.

## 원인
- `api/question.ts` 응답에 crowd 데이터 미포함
- `VotePage`는 voted 상태에서 `api.vote()` 재호출 안 함 → crowd 초기값(Mock) 유지

## 수정
- `api/question.ts`: Supabase 캐시 응답에 `crowd: {bullish, bearish, neutral, totalVotes}` 포함
- `VotePage`: 재진입 시 `q.crowd`로 crowd 상태 초기화
- `client.ts` / `QuestionData` 타입 업데이트

## Test plan
- [ ] 투표 후 앱 재시작 → 군중 비율이 실제 데이터로 표시
- [ ] `pnpm build` ✅ / 92 tests ✅

Closes #190

🤖 Generated by Claude Code [claude-sonnet-4-6]