### PR TITLE
fix: question API voteData 불필요한 쿼리 제거 (#192)

### DIFF
--- a/api/question.ts
+++ b/api/question.ts
@@ -117,12 +117,7 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
       .eq('date', today)
       .single()
     if (existing) {
-      const { data: voteData } = await supabase
-        .from('user_votes')
-        .select('prediction')
-        .eq('question_id', existing.id)
-      const totalVotes = voteData?.length ?? 0
-      const total = existing.total_votes || totalVotes || 1
+      const total = existing.total_votes || 1
       const crowdBullish = Math.round(((existing.crowd_bullish ?? 0) / total) * 100)
       const crowdBearish = Math.round(((existing.crowd_bearish ?? 0) / total) * 100)
       const crowdNeutral = 100 - crowdBullish - crowdBearish
@@ -133,8 +128,8 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
         question: existing.question,
         category: existing.category,
         characters: existing.character_predictions ?? [],
-        totalVotes: existing.total_votes ?? totalVotes,
-        crowd: { bullish: crowdBullish, bearish: crowdBearish, neutral: crowdNeutral, totalVotes: existing.total_votes ?? totalVotes },
+        totalVotes: existing.total_votes ?? 0,
+        crowd: { bullish: crowdBullish, bearish: crowdBearish, neutral: crowdNeutral, totalVotes: existing.total_votes ?? 0 },
         deadline: existing.deadline,
         isActive: new Date() < new Date(existing.deadline),
       }


### PR DESCRIPTION
## 수정
`user_votes.prediction` 컬럼 조회 제거 (컬럼명은 `choice`, 쿼리 항상 실패).
`existing.total_votes` 직접 사용으로 단순화.

Closes #192

🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **최적화**
  * 일일 질문 데이터 조회 시 캐시된 결과에서 투표 정보 계산을 효율화했습니다. 불필요한 추가 쿼리를 제거하여 응답 속도를 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->