### PR TITLE
fix: 이모지 반응 변경 시 이전 카운트 감소

### DIFF
--- a/api/react.ts
+++ b/api/react.ts
@@ -7,10 +7,11 @@ type Reaction = typeof VALID_REACTIONS[number]
 export default async function handler(req: VercelRequest, res: VercelResponse) {
   if (req.method !== 'POST') return res.status(405).json({ error: 'Method not allowed' })
 
-  const { questionId, character, reaction } = req.body as {
+  const { questionId, character, reaction, prevReaction } = req.body as {
     questionId?: string
     character?: string
     reaction?: string
+    prevReaction?: string
   }
 
   if (!questionId || !character || !reaction) {
@@ -35,6 +36,12 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
 
   const allReactions: Record<string, Record<string, number>> = row.character_reactions ?? {}
   const charReactions = { ...(allReactions[character] ?? {}) }
+
+  // 이전 반응 감소
+  if (prevReaction && charReactions[prevReaction] && charReactions[prevReaction] > 0) {
+    charReactions[prevReaction] = charReactions[prevReaction] - 1
+  }
+
   charReactions[reaction] = (charReactions[reaction] ?? 0) + 1
 
   const updated = { ...allReactions, [character]: charReactions }

--- a/src/lib/api/client.ts
+++ b/src/lib/api/client.ts
@@ -52,7 +52,7 @@ export const api = {
     correct: number; total: number; rate: number
   }>>('/leaderboard'),
 
-  react: (body: { questionId: string; character: string; reaction: string }) =>
+  react: (body: { questionId: string; character: string; reaction: string; prevReaction?: string }) =>
     request<{ reactions: Record<string, number> }>('/react', { method: 'POST', body: JSON.stringify(body) }),
 
   getUpdates: (questionId: string) => request<{

--- a/src/pages/VotePage.tsx
+++ b/src/pages/VotePage.tsx
@@ -120,21 +120,24 @@ export function VotePage() {
     setMyReactions(updated)
     localStorage.setItem(`sp_reactions_${questionData.id}`, JSON.stringify(updated))
 
-    // 옵티미스틱 업데이트: 캐릭터 emojiReactions 카운트 증가
-    setQuestionData((prev) => {
-      if (!prev) return prev
+    // 옵티미스틱 업데이트: 이전 반응 감소 + 새 반응 증가
+    setQuestionData((q) => {
+      if (!q) return q
       return {
-        ...prev,
-        characters: prev.characters.map((c) => {
+        ...q,
+        characters: q.characters.map((c) => {
           if (c.character !== character) return c
           const reactions = { ...(c.emojiReactions ?? {}) }
+          if (prev && reactions[prev] && reactions[prev] > 0) {
+            reactions[prev] = reactions[prev] - 1
+          }
           reactions[reaction] = (reactions[reaction] ?? 0) + 1
           return { ...c, emojiReactions: reactions }
         }),
       }
     })
 
-    await api.react({ questionId: questionData.id, character, reaction })
+    await api.react({ questionId: questionData.id, character, reaction, prevReaction: prev })
   }, [questionData, myReactions])
 
   const handleShare = useCallback(async () => {


### PR DESCRIPTION
## 수정
- `api/react.ts`: `prevReaction` 파라미터 추가, 이전 반응 카운트 감소 처리
- `VotePage.tsx`: 옵티미스틱 업데이트에서 이전 반응 카운트도 감소
- `client.ts`: `react()` 타입에 `prevReaction?` 추가

## Test plan
- [x] build 통과

Closes #198

🤖 Generated by Claude Code [claude-sonnet-4-6]