### PR TITLE
refactor: isCrowdCorrect 유틸 추출 + 테스트 92→98개

### DIFF
--- a/src/lib/utils/__tests__/share.test.ts
+++ b/src/lib/utils/__tests__/share.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { generateVoteShareText, generateResultShareText, shareText } from '../share'
+import { generateVoteShareText, generateResultShareText, shareText, isCrowdCorrect } from '../share'
 
 describe('generateVoteShareText', () => {
   it('기본 형식으로 텍스트 생성', () => {
@@ -150,5 +150,31 @@ describe('shareText', () => {
   it('navigator.share 없음 + clipboard 없음 → failed 반환', async () => {
     const result = await shareText('테스트')
     expect(result).toBe('failed')
+  })
+})
+
+describe('isCrowdCorrect', () => {
+  it('bullish 다수 + 실제 bullish → true', () => {
+    expect(isCrowdCorrect({ bullish: 60, bearish: 25, neutral: 15 }, 'bullish')).toBe(true)
+  })
+
+  it('bullish 다수 + 실제 bearish → false', () => {
+    expect(isCrowdCorrect({ bullish: 60, bearish: 25, neutral: 15 }, 'bearish')).toBe(false)
+  })
+
+  it('bearish 다수 + 실제 bearish → true', () => {
+    expect(isCrowdCorrect({ bullish: 20, bearish: 55, neutral: 25 }, 'bearish')).toBe(true)
+  })
+
+  it('neutral 다수 + 실제 neutral → true', () => {
+    expect(isCrowdCorrect({ bullish: 30, bearish: 30, neutral: 40 }, 'neutral')).toBe(true)
+  })
+
+  it('동점(bullish = bearish > neutral) → bullish 선택 → 실제 bullish → true', () => {
+    expect(isCrowdCorrect({ bullish: 40, bearish: 40, neutral: 20 }, 'bullish')).toBe(true)
+  })
+
+  it('동점(bullish = bearish > neutral) → bullish 선택 → 실제 bearish → false', () => {
+    expect(isCrowdCorrect({ bullish: 40, bearish: 40, neutral: 20 }, 'bearish')).toBe(false)
   })
 })

--- a/src/lib/utils/share.ts
+++ b/src/lib/utils/share.ts
@@ -1,4 +1,17 @@
-import type { VoteChoice } from '@/types/vote'
+import type { VoteChoice, CrowdResult } from '@/types/vote'
+
+/**
+ * 군중이 예측한 결과(다수 선택)가 실제 결과와 일치하는지 판단
+ */
+export function isCrowdCorrect(crowd: Pick<CrowdResult, 'bullish' | 'bearish' | 'neutral'>, actual: VoteChoice): boolean {
+  if (crowd.bullish >= crowd.bearish && crowd.bullish >= crowd.neutral) {
+    return actual === 'bullish'
+  }
+  if (crowd.bearish >= crowd.neutral) {
+    return actual === 'bearish'
+  }
+  return actual === 'neutral'
+}
 
 const CHOICE_LABEL: Record<VoteChoice, string> = {
   bullish: '📈 올라갈 듯',

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -12,7 +12,7 @@ import { CrowdBar } from '@/components/vote/CrowdBar'
 import { ShareCard } from '@/components/shared/ShareCard'
 import { getVote } from '@/lib/utils/voteHistory'
 import { recordResult, getStreak, getAccuracyPercent, getCharacterAlignment } from '@/lib/utils/userStats'
-import { generateResultShareText, shareText } from '@/lib/utils/share'
+import { generateResultShareText, shareText, isCrowdCorrect } from '@/lib/utils/share'
 import { MOCK_VOTE_RESULT, MOCK_CHARACTER_ACCURACY } from '@/lib/mockData'
 
 type LeaderboardEntry = { character: string; name: string; emoji: string; correct: number; total: number; rate: number }
@@ -79,12 +79,7 @@ export function ResultPage() {
     }
 
     // 텍스트 폴백
-    const crowdWon = result.crowdResult.bullish >= result.crowdResult.bearish &&
-      result.crowdResult.bullish >= result.crowdResult.neutral
-        ? result.actualOutcome === 'bullish'
-        : result.crowdResult.bearish >= result.crowdResult.neutral
-          ? result.actualOutcome === 'bearish'
-          : result.actualOutcome === 'neutral'
+    const crowdWon = isCrowdCorrect(result.crowdResult, result.actualOutcome)
     const text = generateResultShareText({
       title: result.title,
       crowdCorrect: crowdWon,
@@ -119,12 +114,7 @@ export function ResultPage() {
     )
   }
 
-  const crowdCorrect = result.crowdResult.bullish >= result.crowdResult.bearish &&
-    result.crowdResult.bullish >= result.crowdResult.neutral
-      ? result.actualOutcome === 'bullish'
-      : result.crowdResult.bearish >= result.crowdResult.neutral
-        ? result.actualOutcome === 'bearish'
-        : result.actualOutcome === 'neutral'
+  const crowdCorrect = isCrowdCorrect(result.crowdResult, result.actualOutcome)
 
   const correctCount = result.characters.filter((c) => c.isCorrect).length
 


### PR DESCRIPTION
## Summary
- `isCrowdCorrect(crowd, actual)` 유틸 함수 추출 — ResultPage 중복 계산 제거
- 테스트 6개 추가 (동점 케이스 포함): 92 → 98개

## Test plan
- [x] build 통과
- [x] 유닛 98/98 통과

Closes #200

🤖 Generated by Claude Code [claude-sonnet-4-6]