### PR TITLE
refactor: formatDeadline format.ts 추출 + 테스트 98→101개

### DIFF
--- a/src/lib/utils/__tests__/format.test.ts
+++ b/src/lib/utils/__tests__/format.test.ts
@@ -4,6 +4,7 @@ import {
   formatTimeRemaining,
   formatDate,
   formatPercent,
+  formatDeadline,
 } from '../format'
 
 describe('formatScore', () => {
@@ -77,5 +78,25 @@ describe('formatPercent', () => {
 
   it('0 → 0%', () => {
     expect(formatPercent(0)).toBe('0%')
+  })
+})
+
+describe('formatDeadline', () => {
+  beforeEach(() => vi.useFakeTimers())
+  afterEach(() => vi.useRealTimers())
+
+  it('2시간 후 → 2시간 후 마감', () => {
+    vi.setSystemTime(new Date('2026-03-26T10:00:00Z'))
+    expect(formatDeadline('2026-03-26T12:00:00Z')).toBe('2시간 후 마감')
+  })
+
+  it('30분 후 → 30분 후 마감', () => {
+    vi.setSystemTime(new Date('2026-03-26T10:00:00Z'))
+    expect(formatDeadline('2026-03-26T10:30:00Z')).toBe('30분 후 마감')
+  })
+
+  it('이미 지난 시간 → 투표 마감', () => {
+    vi.setSystemTime(new Date('2026-03-26T10:00:00Z'))
+    expect(formatDeadline('2026-03-26T09:00:00Z')).toBe('투표 마감')
   })
 })

--- a/src/lib/utils/format.ts
+++ b/src/lib/utils/format.ts
@@ -38,3 +38,15 @@ export function formatDate(dateStr: string): string {
 export function formatPercent(value: number): string {
   return `${Math.round(value)}%`
 }
+
+/**
+ * 투표 마감까지 남은 시간 — "N시간 후 마감" / "N분 후 마감" / "투표 마감"
+ */
+export function formatDeadline(deadline: string): string {
+  const diff = new Date(deadline).getTime() - Date.now()
+  if (diff <= 0) return '투표 마감'
+  const hours = Math.floor(diff / 3600000)
+  if (hours >= 1) return `${hours}시간 후 마감`
+  const minutes = Math.floor(diff / 60000)
+  return `${minutes}분 후 마감`
+}

--- a/src/pages/VotePage.tsx
+++ b/src/pages/VotePage.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom'
 import { useWebToast, useBottomSheet } from '@toss/tds-mobile'
 import { TdsButton as Button } from '@/components/shared/TdsButton'
 import { generateVoteShareText, shareText } from '@/lib/utils/share'
+import { formatDeadline } from '@/lib/utils/format'
 import { saveVote, getVote } from '@/lib/utils/voteHistory'
 import { recordVote } from '@/lib/utils/userStats'
 import { TdsBadge as Badge } from '@/components/shared/TdsBadge'
@@ -26,14 +27,6 @@ const VOTE_OPTIONS: { value: VoteChoice; label: string; emoji: string }[] = [
   { value: 'bearish', label: '망할 듯', emoji: '📉' },
 ]
 
-function formatDeadline(deadline: string): string {
-  const diff = new Date(deadline).getTime() - Date.now()
-  if (diff <= 0) return '투표 마감'
-  const hours = Math.floor(diff / 3600000)
-  if (hours >= 1) return `${hours}시간 후 마감`
-  const minutes = Math.floor(diff / 60000)
-  return `${minutes}분 후 마감`
-}
 
 const FIRST_VOTE_KEY = 'sp_first_vote_explained'
 


### PR DESCRIPTION
## Summary
- `formatDeadline` 함수를 VotePage 인라인 → `format.ts` 모듈로 이동
- 테스트 3개 추가 (2시간, 30분, 마감 케이스): 98 → 101개

Closes #204

🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Tests**
  * 마감 시간 형식화 기능에 대한 테스트 스위트 추가

* **Refactor**
  * 마감 시간 형식화 로직을 공유 유틸리티로 통합하여 코드 중복성 감소

<!-- end of auto-generated comment: release notes by coderabbit.ai -->