### PR TITLE
feat: ResultPage 이모지 반응 카운트 읽기전용 노출

### DIFF
--- a/api/result.ts
+++ b/api/result.ts
@@ -29,12 +29,14 @@ export default async function handler(req: VercelRequest, res: VercelResponse) {
   const closeReactions = (data.close_reactions ?? []) as Array<{ character: string; comment: string }>
   for (const r of closeReactions) reactionsMap[r.character] = r.comment
 
-  // 캐릭터별 isCorrect + reaction 병합
+  // 캐릭터별 isCorrect + reaction + emojiReactions 병합
+  const emojiReactionsMap: Record<string, Record<string, number>> = data.character_reactions ?? {}
   const characters = (data.character_predictions ?? []).map(
     (c: { character: string; name: string; emoji: string; methodology: string; prediction: string; reasoning: string }) => ({
       ...c,
       isCorrect: c.prediction === data.actual_outcome,
       ...(reactionsMap[c.character] ? { reaction: reactionsMap[c.character] } : {}),
+      emojiReactions: emojiReactionsMap[c.character] ?? {},
     })
   )
 

--- a/src/components/vote/CharacterCard.tsx
+++ b/src/components/vote/CharacterCard.tsx
@@ -126,17 +126,20 @@ export function CharacterCard({ prediction, isCorrect, showCorrect = false, defa
             </p>
           )}
 
-          {voted && onReact && (
+          {voted && (prediction.emojiReactions || onReact) && (
             <div className={styles.emojiReactions} onClick={(e) => e.stopPropagation()}>
               {REACTIONS.map((r) => {
                 const count = prediction.emojiReactions?.[r] ?? 0
                 const isMe = myReaction === r
+                if (!onReact && count === 0) return null
                 return (
                   <button
                     key={r}
                     className={`${styles.reactionBtn} ${isMe ? styles.reactionBtnActive : ''}`}
-                    onClick={() => onReact(r)}
+                    onClick={() => onReact?.(r)}
+                    disabled={!onReact}
                     aria-label={REACTION_LABELS[r]}
+                    style={!onReact ? { cursor: 'default' } : undefined}
                   >
                     {r} {count > 0 && <span className={styles.reactionCount}>{count}</span>}
                   </button>

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -209,6 +209,7 @@ export function ResultPage() {
               prediction={char}
               isCorrect={char.isCorrect}
               showCorrect
+              voted
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary
- `api/result.ts`: characters에 `emojiReactions` 포함
- `CharacterCard`: `voted && !onReact` → 카운트 표시(클릭 불가), count=0인 버튼 숨김
- `ResultPage`: `voted` prop 전달 → 투표한 결과 화면에서 반응 집계 확인 가능

Closes #206

🤖 Generated by Claude Code [claude-sonnet-4-6]