### PR TITLE
feat: 레벨 시스템 — 누적 투표 수 기반 5단계 레벨 (시장 구경꾼 → 시그널 마스터)

### DIFF
--- a/src/components/shared/ShareCard.tsx
+++ b/src/components/shared/ShareCard.tsx
@@ -1,16 +1,18 @@
 import type { VoteResult } from '@/types/vote'
 import type { VoteRecord } from '@/lib/utils/voteHistory'
+import type { LevelInfo } from '@/lib/utils/userStats'
 
 interface Props {
   result: VoteResult
   myVote: VoteRecord | null
   streak: number
   accuracyPercent: number | null
+  level?: LevelInfo | null
 }
 
 const OUTCOME_LABELS = { bullish: '올라갔다 📈', bearish: '망했다 📉', neutral: '그냥 그랬다 🤷' } as const
 
-export function ShareCard({ result, myVote, streak, accuracyPercent }: Props) {
+export function ShareCard({ result, myVote, streak, accuracyPercent, level }: Props) {
   const isCorrect = myVote?.choice === result.actualOutcome
   const correctCount = result.characters.filter((c) => c.isCorrect).length
 
@@ -91,8 +93,14 @@ export function ShareCard({ result, myVote, streak, accuracyPercent }: Props) {
       </div>
 
       {/* Stats */}
-      {(streak > 0 || accuracyPercent !== null) && (
-        <div style={{ display: 'flex', gap: 6 }}>
+      {(level || streak > 0 || accuracyPercent !== null) && (
+        <div style={{ display: 'flex', gap: 6, flexWrap: 'wrap' }}>
+          {level && (
+            <span style={{
+              fontSize: 11, background: '#f0e8ff', color: '#7c3aed',
+              borderRadius: 6, padding: '3px 8px', fontWeight: 600,
+            }}>{level.emoji} Lv.{level.level} {level.label}</span>
+          )}
           {streak > 0 && (
             <span style={{
               fontSize: 11, background: '#e8f0ff', color: '#3182f6',

--- a/src/lib/utils/__tests__/userStats.test.ts
+++ b/src/lib/utils/__tests__/userStats.test.ts
@@ -5,6 +5,8 @@ import {
   getStreak,
   getAccuracyPercent,
   getCharacterAlignment,
+  getLevel,
+  getTotalVotes,
 } from '../userStats'
 
 // localStorage mock
@@ -86,6 +88,51 @@ describe('recordResult / getAccuracyPercent', () => {
     recordResult('q-003', true)
     recordResult('q-004', true)
     expect(getAccuracyPercent()).toBe(75)
+  })
+})
+
+describe('getLevel / getTotalVotes', () => {
+  it('투표 없으면 null', () => {
+    expect(getLevel()).toBeNull()
+    expect(getTotalVotes()).toBe(0)
+  })
+
+  it('1회 → Lv.1 시장 구경꾼', () => {
+    recordVote('2026-03-01')
+    expect(getLevel()?.level).toBe(1)
+    expect(getLevel()?.label).toBe('시장 구경꾼')
+  })
+
+  it('9회 → 여전히 Lv.1', () => {
+    store['sp_user_stats'] = JSON.stringify({ streak: 1, lastVoteDate: '2026-01-01', correct: 0, total: 0, lastScoredQuestionId: null, totalVotes: 9 })
+    expect(getLevel()?.level).toBe(1)
+    expect(getTotalVotes()).toBe(9)
+  })
+
+  it('10회 → Lv.2 초보 분석가', () => {
+    store['sp_user_stats'] = JSON.stringify({ streak: 1, lastVoteDate: '2026-01-01', correct: 0, total: 0, lastScoredQuestionId: null, totalVotes: 10 })
+    expect(getLevel()?.level).toBe(2)
+    expect(getLevel()?.label).toBe('초보 분석가')
+  })
+
+  it('30회 → Lv.3 시장 감시자', () => {
+    store['sp_user_stats'] = JSON.stringify({ streak: 1, lastVoteDate: '2026-01-01', correct: 0, total: 0, lastScoredQuestionId: null, totalVotes: 30 })
+    expect(getLevel()?.level).toBe(3)
+    expect(getLevel()?.label).toBe('시장 감시자')
+  })
+
+  it('100회 → Lv.4 프로 예측가, nextAt=365', () => {
+    store['sp_user_stats'] = JSON.stringify({ streak: 1, lastVoteDate: '2026-01-01', correct: 0, total: 0, lastScoredQuestionId: null, totalVotes: 100 })
+    expect(getLevel()?.level).toBe(4)
+    expect(getLevel()?.nextAt).toBe(365)
+  })
+
+  it('365회 → Lv.5 시그널 마스터, nextAt=null', () => {
+    const key = 'sp_user_stats'
+    store[key] = JSON.stringify({ streak: 1, lastVoteDate: '2026-01-01', correct: 0, total: 0, lastScoredQuestionId: null, totalVotes: 365 })
+    expect(getLevel()?.level).toBe(5)
+    expect(getLevel()?.label).toBe('시그널 마스터')
+    expect(getLevel()?.nextAt).toBeNull()
   })
 })
 

--- a/src/lib/utils/userStats.ts
+++ b/src/lib/utils/userStats.ts
@@ -8,6 +8,7 @@ interface UserStats {
   correct: number
   total: number
   lastScoredQuestionId: string | null
+  totalVotes: number
 }
 
 const DEFAULT_STATS: UserStats = {
@@ -16,6 +17,7 @@ const DEFAULT_STATS: UserStats = {
   correct: 0,
   total: 0,
   lastScoredQuestionId: null,
+  totalVotes: 0,
 }
 
 function getStats(): UserStats {
@@ -33,7 +35,7 @@ function saveStats(stats: UserStats): void {
   } catch { /* storage full — silent fail */ }
 }
 
-/** 투표 시 호출: 스트릭 업데이트 */
+/** 투표 시 호출: 스트릭 + 누적 투표 수 업데이트 */
 export function recordVote(date: string): void {
   const stats = getStats()
   if (stats.lastVoteDate === date) return // 오늘 이미 업데이트됨
@@ -44,7 +46,7 @@ export function recordVote(date: string): void {
 
   const newStreak = stats.lastVoteDate === yesterdayStr ? stats.streak + 1 : 1
 
-  saveStats({ ...stats, streak: newStreak, lastVoteDate: date })
+  saveStats({ ...stats, streak: newStreak, lastVoteDate: date, totalVotes: (stats.totalVotes ?? 0) + 1 })
 }
 
 /** ResultPage에서 결과 확인 시 호출: 적중률 업데이트 (중복 방지) */
@@ -78,6 +80,37 @@ const CHARACTER_NAMES: Record<string, { name: string; emoji: string }> = {
   reporter:  { name: '뉴스최', emoji: '📺' },
   pattern:   { name: '봉준선', emoji: '📐' },
   chimp:     { name: '코인토', emoji: '🎲' },
+}
+
+export interface LevelInfo {
+  level: number
+  label: string
+  emoji: string
+  nextAt: number | null  // 다음 레벨까지 필요한 총 투표 수 (Lv.5면 null)
+}
+
+const LEVELS: LevelInfo[] = [
+  { level: 1, label: '시장 구경꾼',   emoji: '👀', nextAt: 10  },
+  { level: 2, label: '초보 분석가',   emoji: '📊', nextAt: 30  },
+  { level: 3, label: '시장 감시자',   emoji: '🔭', nextAt: 100 },
+  { level: 4, label: '프로 예측가',   emoji: '🎯', nextAt: 365 },
+  { level: 5, label: '시그널 마스터', emoji: '🏆', nextAt: null },
+]
+
+/** 누적 투표 수 기반 레벨 — 1회 미만이면 null */
+export function getLevel(): LevelInfo | null {
+  const votes = getStats().totalVotes ?? 0
+  if (votes < 1) return null
+  if (votes >= 365) return LEVELS[4]
+  if (votes >= 100) return LEVELS[3]
+  if (votes >= 30)  return LEVELS[2]
+  if (votes >= 10)  return LEVELS[1]
+  return LEVELS[0]
+}
+
+/** 누적 총 투표 수 */
+export function getTotalVotes(): number {
+  return getStats().totalVotes ?? 0
 }
 
 /** 누적 투표 기반 가장 일치하는 캐릭터 — 3회 미만 투표 시 null */

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -11,7 +11,7 @@ import { CharacterCard } from '@/components/vote/CharacterCard'
 import { CrowdBar } from '@/components/vote/CrowdBar'
 import { ShareCard } from '@/components/shared/ShareCard'
 import { getVote } from '@/lib/utils/voteHistory'
-import { recordResult, getStreak, getAccuracyPercent, getCharacterAlignment } from '@/lib/utils/userStats'
+import { recordResult, getStreak, getAccuracyPercent, getCharacterAlignment, getLevel } from '@/lib/utils/userStats'
 import { generateResultShareText, shareText, isCrowdCorrect } from '@/lib/utils/share'
 import { MOCK_VOTE_RESULT, MOCK_CHARACTER_ACCURACY } from '@/lib/mockData'
 
@@ -157,9 +157,13 @@ export function ResultPage() {
         const streak = getStreak()
         const accuracy = getAccuracyPercent()
         const alignment = getCharacterAlignment()
-        if (streak === 0 && accuracy === null && alignment === null) return null
+        const level = getLevel()
+        if (streak === 0 && accuracy === null && alignment === null && !level) return null
         return (
           <div className={styles.statsRow}>
+            {level && (
+              <Badge size="small" variant="weak" color="purple">{level.emoji} Lv.{level.level} {level.label}</Badge>
+            )}
             {streak > 0 && (
               <Badge size="small" variant="weak" color="blue">🔥 {streak}일 연속</Badge>
             )}
@@ -257,6 +261,7 @@ export function ResultPage() {
           myVote={myVote}
           streak={getStreak()}
           accuracyPercent={getAccuracyPercent()}
+          level={getLevel()}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary

서비스 기획 v2 §3-2 사용자 성과 축적 시스템 — 레벨 시스템 MVP.

- 누적 투표 수 기반 5단계 레벨: 시장 구경꾼(1~9) → 초보 분석가(10~29) → 시장 감시자(30~99) → 프로 예측가(100~364) → 시그널 마스터(365+)
- ResultPage stats row에 레벨 배지 최상단 노출 (`Lv.1 시장 구경꾼`)
- 공유 카드(ShareCard)에 레벨 뱃지 포함 — 공유 시 레벨 자랑 가능
- `recordVote()` 호출 시 `totalVotes` 누적 카운터 증가 (all-time, 만료 없음)
- 유닛 테스트 7개 추가: 경계값(1/9/10/30/100/365회) + getTotalVotes 검증

## Test plan

- [ ] 유닛 테스트 108개 전체 통과
- [ ] TypeScript 에러 0개
- [ ] ResultPage: 첫 투표 후 stats row에 `👀 Lv.1 시장 구경꾼` 배지 노출
- [ ] 공유 카드에 레벨 배지 포함 확인

**[역할 리뷰]** 판정: 승인 — 기존 userStats 인프라 확장, 래칫 상향(101→108), 빌드 클린.

🤖 Generated by Claude Code [claude-sonnet-4-6]