### PR TITLE
feat: 리더보드 '나' 행 추가 — 캐릭터와 직접 순위 비교

### DIFF
--- a/src/pages/ResultPage.module.css
+++ b/src/pages/ResultPage.module.css
@@ -134,6 +134,13 @@
   color: var(--color-text-secondary);
 }
 
+.syncMsg {
+  font-size: 13px;
+  color: var(--color-primary);
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
 /* Leaderboard */
 .leaderboard {
   display: flex;
@@ -145,6 +152,14 @@
   display: flex;
   align-items: center;
   gap: 8px;
+}
+
+.leaderRowMe {
+  background: rgba(49, 130, 246, 0.08);
+  border: 1.5px solid rgba(49, 130, 246, 0.3);
+  border-radius: 8px;
+  padding: 4px 6px;
+  margin: 0 -6px;
 }
 
 .leaderRank {

--- a/src/pages/ResultPage.tsx
+++ b/src/pages/ResultPage.tsx
@@ -226,22 +226,35 @@ export function ResultPage() {
       </div>
 
       {/* This month leaderboard */}
-      <div className={styles.section}>
-        <h3 className={styles.sectionTitle}>이번 달 누가 제일 잘 맞혔냐 🏆</h3>
-        <div className={styles.leaderboard}>
-          {leaderboard.map((c, i) => (
-            <div key={c.character} className={styles.leaderRow}>
-              <span className={styles.leaderRank}>{i + 1}</span>
-              <span className={styles.leaderEmoji}>{c.emoji}</span>
-              <span className={styles.leaderName}>{c.name}</span>
-              <div className={styles.leaderBarWrap}>
-                <div className={styles.leaderBar} style={{ width: `${c.rate}%` }} />
-              </div>
-              <span className={styles.leaderRate}>{c.rate}%</span>
+      {(() => {
+        const myAccuracy = getAccuracyPercent()
+        const combined = myAccuracy !== null
+          ? [...leaderboard, { character: 'me', name: '나', emoji: '🙋', correct: 0, total: 0, rate: myAccuracy }].sort((a, b) => b.rate - a.rate)
+          : leaderboard
+        const myRank = combined.findIndex((c) => c.character === 'me')
+        const beatenCount = leaderboard.filter((c) => c.rate < (myAccuracy ?? 0)).length
+        return (
+          <div className={styles.section}>
+            <h3 className={styles.sectionTitle}>이번 달 누가 제일 잘 맞혔냐 🏆</h3>
+            {myAccuracy !== null && beatenCount > 0 && (
+              <p className={styles.syncMsg}>🎉 {beatenCount}명의 전문가를 이겼어요!</p>
+            )}
+            <div className={styles.leaderboard}>
+              {combined.map((c, i) => (
+                <div key={c.character} className={`${styles.leaderRow} ${c.character === 'me' ? styles.leaderRowMe : ''}`}>
+                  <span className={styles.leaderRank}>{i + 1}</span>
+                  <span className={styles.leaderEmoji}>{c.emoji}</span>
+                  <span className={styles.leaderName}>{c.name}</span>
+                  <div className={styles.leaderBarWrap}>
+                    <div className={styles.leaderBar} style={{ width: `${c.rate}%` }} />
+                  </div>
+                  <span className={styles.leaderRate}>{c.rate}%</span>
+                </div>
+              ))}
             </div>
-          ))}
-        </div>
-      </div>
+          </div>
+        )
+      })()}
 
       <div className={styles.actions}>
         <Button size="medium" variant="fill" color="primary" onClick={() => navigate('/')}>


### PR DESCRIPTION
## Summary

서비스 기획 v2 §3-3 "나 vs 캐릭터" 통합 리더보드 구현.

- 사용자 적중률(localStorage)을 캐릭터 5명과 함께 정렬 후 "나 🙋" 행 삽입
- "나" 행은 파란 테두리로 하이라이트 (`.leaderRowMe`)
- 캐릭터보다 높을 때: "🎉 N명의 전문가를 이겼어요!" 동기부여 문구
- 적중률 없는 첫 방문자 → 기존 5인 리더보드 유지 (회귀 없음)
- API 변경 없음 — 순수 프론트엔드

## Test plan

- [ ] 유닛 테스트 108개 전체 통과
- [ ] TypeScript 에러 0개
- [ ] 적중률 있을 때 "나" 행 파란 테두리로 정렬된 위치에 노출
- [ ] 첫 방문 시 "나" 행 미노출

**[역할 리뷰]** 판정: 승인 — 기존 leaderboard 섹션 범위 내 개선, 래칫 유지(108개).

🤖 Generated by Claude Code [claude-sonnet-4-6]

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능
* 리더보드에 사용자 순위 표시 - 사용자의 정확도를 바탕으로 리더보드에 자신의 항목이 추가되고 강조 표시됩니다.
* 축하 메시지 추가 - 사용자가 다른 전문가를 초과 달성할 때 축하 메시지가 표시됩니다.

## 스타일
* 사용자 리더보드 항목의 시각적 스타일링 개선 및 강조 표시 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->